### PR TITLE
add version menu to download page

### DIFF
--- a/pages/download.html
+++ b/pages/download.html
@@ -28,6 +28,12 @@ $(document).ready(function() {
 {% endblock %}
 
 {% block body %}
+<div id="downloadmenu">
+<ul>
+<li><a href="#stable">{% trans "Stable 1.11" %}</li>
+<li><a href="#beta">{% trans "Dev 2.0-rc1" %}</li>
+</ul>
+</div>
 <div class="content">
   <div style="float: right; width: 100px; padding-top: 30px;">
     <center>{% include "donate_paypal.html" %}</center>

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -277,3 +277,6 @@ h2 a {
     padding: 0px;
     list-style-type: none;
 }
+#downloadmenu li {
+    margin: 0.2em 0;
+}

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -261,3 +261,19 @@ h2 a {
     font-size: 0.7em;
     text-align: center;
 }
+#downloadmenu {
+    position:fixed;
+    width:100px;
+    top:10%;
+    left:5px
+}
+@media only screen and (max-width: 1150px) {
+    #downloadmenu {
+        display: none;
+    }
+}
+#downloadmenu ul
+{
+    padding: 0px;
+    list-style-type: none;
+}

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -272,8 +272,7 @@ h2 a {
         display: none;
     }
 }
-#downloadmenu ul
-{
+#downloadmenu ul {
     padding: 0px;
     list-style-type: none;
 }


### PR DESCRIPTION
Add a fixed-positionned menu on the left of download page (only if screen size > 1150px because we don't have space for that on smaller screens) to make 2.0-rc1 more visible to users clicking on the large download button of the homepage.
