### PR TITLE
mixxx-devel as annoncment channel until Zulip has default notification streams. 

### DIFF
--- a/pages/support.html
+++ b/pages/support.html
@@ -32,7 +32,7 @@
   <div class="halfbox_left">
     <h2>{% trans "User Manual" %}</h2>
     <p>
-      {% blocktrans with manual_latest_link="/manual/latest" manual_beginner_link="/manual/latest/chapters/djing_with_mixxx.html" %}The <a href="{{ manual_latest_link }}">Mixxx Manual</a> provides an overview of Mixxx's user interface, information about <b>configuration</b> and hardware, and much more. It also contains useful information for <b>beginners</b> under <a href="{{ manual_beginner_link }}">DJing with Mixxx</a>.{% endblocktrans %}
+      {% blocktrans with manual_latest_link="/manual/latest" manual_beginner_link="/manual/latest/chapters/djing_with_mixxx.html" %}The <a href="{{ manual_latest_link }}">Mixxx Manual</a> provides an overview of Mixxx's user interface, information about configuration and hardware, and much more. It also contains useful information for beginners under <a href="{{ manual_beginner_link }}">DJing with Mixxx</a>.{% endblocktrans %}
     </p>
   </div>
 

--- a/pages/support.html
+++ b/pages/support.html
@@ -14,26 +14,26 @@
   <div style="clear: both;"></div>
 
   <div class="halfbox_left">
-    <H2>{% trans "Wiki" %}</H2>
-    <p>
-      {% blocktrans with mixxx_wiki_link="/wiki/" beginner_dj_links="/wiki/doku.php/beginner_dj_links" wiki_troubleshooting="/wiki/doku.php/troubleshooting" %}The <a href="{{ mixxx_wiki_link }}">Mixxx Wiki</a> has a wealth of useful documentation for users and developers. New to it all and not sure how to get started? Checkout the <a href="{{ beginner_dj_links }}">Beginner DJ Links</a>. Running into technical issues? See the <a href="{{ wiki_troubleshooting }}">Troubleshooting</a> guide. {% endblocktrans %}
-    </p>
-  </div>
-
-  <div class="halfbox_right">
-    <H2>{% trans "User Manual" %}</H2>
-    <p>
-      {% blocktrans with manual_latest_link="/manual/latest" manual_beginner_link="/manual/latest/chapters/djing_with_mixxx.html" %}The <a href="{{ manual_latest_link }}">Mixxx Manual</a> provides an overview of Mixxx's user interface, information about <b>configuration</b> and hardware, and much more. It also contains useful information for <b>beginners</b> under <a href="{{ manual_beginner_link }}">DJing with Mixxx</a>.{% endblocktrans %}
-    </p>
-  </div>
-  <div style="clear: both;"></div>
-
-  <div class="halfbox_left">
     <h2>{% trans "Community Forums" %}</h2>
     <p>
       {% blocktrans with forums_link="/forums" %}Have a Mixxx-related question? Something other DJs can help you with? Ask in the <a href="{{ forums_link }}">Mixxx Community Forums</a>.{% endblocktrans %}
     </p>
   </div>
+
+  <div class="halfbox_right">
+    <h2>{% trans "Wiki" %}</h2>
+    <p>
+      {% blocktrans with mixxx_wiki_link="/wiki/" beginner_dj_links="/wiki/doku.php/beginner_dj_links" wiki_troubleshooting="/wiki/doku.php/troubleshooting" %}The <a href="{{ mixxx_wiki_link }}">Mixxx Wiki</a> has a wealth of useful documentation for users and developers. New to it all and not sure how to get started? Checkout the <a href="{{ beginner_dj_links }}">Beginner DJ Links</a>. Running into technical issues? See the <a href="{{ wiki_troubleshooting }}">Troubleshooting</a> guide. {% endblocktrans %}
+    </p>
+  </div>
+
+  <div class="halfbox_left">
+    <h2>{% trans "User Manual" %}</h2>
+    <p>
+      {% blocktrans with manual_latest_link="/manual/latest" manual_beginner_link="/manual/latest/chapters/djing_with_mixxx.html" %}The <a href="{{ manual_latest_link }}">Mixxx Manual</a> provides an overview of Mixxx's user interface, information about <b>configuration</b> and hardware, and much more. It also contains useful information for <b>beginners</b> under <a href="{{ manual_beginner_link }}">DJing with Mixxx</a>.{% endblocktrans %}
+    </p>
+  </div>
+  <div style="clear: both;"></div>
 
   <div class="halfbox_right">
     <h2>{% trans "Zulip Chat" %}</h2>
@@ -42,8 +42,12 @@
     </p>
   </div>
 
-  <div style="clear: both;"></div>
-
+  <div class="halfbox_left">
+    <h2>{% trans "Mailing List" %}</h2>
+    <p>
+      {% blocktrans with mailing_list_link="https://lists.sourceforge.net/lists/listinfo/mixxx-devel" sourceforge_archive_link="http://sourceforge.net/mailarchive/forum.php?forum=mixxx-devel" gmane_archive_link="http://news.gmane.org/gmane.comp.multimedia.mixxx.devel" %}The <a href="{{ mailing_list_link}} ">mixxx-devel</a> mailing list (<a href="{{ sourceforge_archive_link }}">SourceForge</a> and <a href="{{ gmane_archive_link }}">Gmane</a> archives) is now a low traffic anouncment channel. Subscribe to this list, if you like to keep informed about new releases and other topics. {% endblocktrans %}
+    </p>
+  </div>
   <div class="halfbox_right">
     <h2>{% trans "Bug Tracker" %}</h2>
     <p>

--- a/pages/support.html
+++ b/pages/support.html
@@ -26,14 +26,15 @@
       {% blocktrans with mixxx_wiki_link="/wiki/" beginner_dj_links="/wiki/doku.php/beginner_dj_links" wiki_troubleshooting="/wiki/doku.php/troubleshooting" %}The <a href="{{ mixxx_wiki_link }}">Mixxx Wiki</a> has a wealth of useful documentation for users and developers. New to it all and not sure how to get started? Checkout the <a href="{{ beginner_dj_links }}">Beginner DJ Links</a>. Running into technical issues? See the <a href="{{ wiki_troubleshooting }}">Troubleshooting</a> guide. {% endblocktrans %}
     </p>
   </div>
-
+ 
+  <div style="clear: both;"></div>
+  
   <div class="halfbox_left">
     <h2>{% trans "User Manual" %}</h2>
     <p>
       {% blocktrans with manual_latest_link="/manual/latest" manual_beginner_link="/manual/latest/chapters/djing_with_mixxx.html" %}The <a href="{{ manual_latest_link }}">Mixxx Manual</a> provides an overview of Mixxx's user interface, information about <b>configuration</b> and hardware, and much more. It also contains useful information for <b>beginners</b> under <a href="{{ manual_beginner_link }}">DJing with Mixxx</a>.{% endblocktrans %}
     </p>
   </div>
-  <div style="clear: both;"></div>
 
   <div class="halfbox_right">
     <h2>{% trans "Zulip Chat" %}</h2>
@@ -41,6 +42,8 @@
       {% blocktrans with zulip_web_link="https://mixxx.zulipchat.com/" zulip_app_link="https://zulipchat.com/apps/" %}<a href="{{ zulip_web_link }}">Mixxx's Zulip chat instance</a> is a fun place to hang out with the developers and meet some fellow DJs. Here, the Mixxx team discusses upcoming changes and programming related stuff. It can be used for support too. Join the discussion <a href="{{ zulip_web_link }} ">on the web</a> or download the <a href="{{ zulip_app_link }}">Zulip app</a> and configure it to use the server mixxx.zulipchat.com. {% endblocktrans %}
     </p>
   </div> 
+
+  <div style="clear: both;"></div>
 
   <div class="halfbox_left">
     <h2>{% trans "Mailing List" %}</h2>
@@ -55,6 +58,7 @@
       {% blocktrans with bug_tracker_link="https://bugs.launchpad.net/mixxx/" %}Please report any bugs you find to our <a href=" {{ bug_tracker_link }}">Bug Tracker</a>. The bug tracker gives us a centralized place to pool our information on bugs, and prevents us from getting disorganized and forgetting about them.{% endblocktrans %}
     </p>
   </div>
+
   <div style="clear: both;"></div>
 
 </div>

--- a/pages/support.html
+++ b/pages/support.html
@@ -14,9 +14,9 @@
   <div style="clear: both;"></div>
 
   <div class="halfbox_left">
-    <h2>{% trans "Community Forums" %}</h2>
+    <h2>{% trans "User Manual" %}</h2>
     <p>
-      {% blocktrans with forums_link="/forums" %}Have a Mixxx-related question? Something other DJs can help you with? Ask in the <a href="{{ forums_link }}">Mixxx Community Forums</a>.{% endblocktrans %}
+      {% blocktrans with manual_latest_link="/manual/latest" manual_beginner_link="/manual/latest/chapters/djing_with_mixxx.html" %}The <a href="{{ manual_latest_link }}">Mixxx Manual</a> provides an overview of Mixxx's user interface, information about configuration and hardware, and much more. It also contains useful information for beginners under <a href="{{ manual_beginner_link }}">DJing with Mixxx</a>.{% endblocktrans %}
     </p>
   </div>
 
@@ -30,9 +30,9 @@
   <div style="clear: both;"></div>
   
   <div class="halfbox_left">
-    <h2>{% trans "User Manual" %}</h2>
+    <h2>{% trans "Community Forums" %}</h2>
     <p>
-      {% blocktrans with manual_latest_link="/manual/latest" manual_beginner_link="/manual/latest/chapters/djing_with_mixxx.html" %}The <a href="{{ manual_latest_link }}">Mixxx Manual</a> provides an overview of Mixxx's user interface, information about configuration and hardware, and much more. It also contains useful information for beginners under <a href="{{ manual_beginner_link }}">DJing with Mixxx</a>.{% endblocktrans %}
+      {% blocktrans with forums_link="/forums" %}Have a Mixxx-related question? Something other DJs can help you with? Ask in the <a href="{{ forums_link }}">Mixxx Community Forums</a>. This is also the place to find or share additional controller mappings, keyboard mappings, skin and script tweaks. You may also post your mixes and promote your upcoming gigs there. {% endblocktrans %}
     </p>
   </div>
 

--- a/pages/support.html
+++ b/pages/support.html
@@ -38,9 +38,9 @@
   <div class="halfbox_right">
     <h2>{% trans "Zulip Chat" %}</h2>
     <p>
-      {% blocktrans with zulip_web_link="https://mixxx.zulipchat.com/" zulip_app_link="https://zulipchat.com/apps/" %}<a href="{{ zulip_web_link }}">Mixxx's Zulip chat instance</a> can be used for support too. If you don't need support, Zulip is still a fun place to hang out with the developers and meet some fellow DJs. Join the discussion <a href="{{ zulip_web_link }} ">on the web</a> or download the <a href="{{ zulip_app_link }}">Zulip app</a> and configure it to use the server mixxx.zulipchat.com{% endblocktrans %}
+      {% blocktrans with zulip_web_link="https://mixxx.zulipchat.com/" zulip_app_link="https://zulipchat.com/apps/" %}<a href="{{ zulip_web_link }}">Mixxx's Zulip chat instance</a> is a fun place to hang out with the developers and meet some fellow DJs. Here, the Mixxx team discusses upcoming changes and programming related stuff. It can be used for support too. Join the discussion <a href="{{ zulip_web_link }} ">on the web</a> or download the <a href="{{ zulip_app_link }}">Zulip app</a> and configure it to use the server mixxx.zulipchat.com. {% endblocktrans %}
     </p>
-  </div>
+  </div> 
 
   <div class="halfbox_left">
     <h2>{% trans "Mailing List" %}</h2>
@@ -48,6 +48,7 @@
       {% blocktrans with mailing_list_link="https://lists.sourceforge.net/lists/listinfo/mixxx-devel" sourceforge_archive_link="http://sourceforge.net/mailarchive/forum.php?forum=mixxx-devel" gmane_archive_link="http://news.gmane.org/gmane.comp.multimedia.mixxx.devel" %}The <a href="{{ mailing_list_link}} ">mixxx-devel</a> mailing list (<a href="{{ sourceforge_archive_link }}">SourceForge</a> and <a href="{{ gmane_archive_link }}">Gmane</a> archives) is now a low traffic anouncment channel. Subscribe to this list, if you like to keep informed about new releases and other topics. {% endblocktrans %}
     </p>
   </div>
+
   <div class="halfbox_right">
     <h2>{% trans "Bug Tracker" %}</h2>
     <p>

--- a/pages/support.html
+++ b/pages/support.html
@@ -48,7 +48,7 @@
   <div class="halfbox_left">
     <h2>{% trans "Mailing List" %}</h2>
     <p>
-      {% blocktrans with mailing_list_link="https://lists.sourceforge.net/lists/listinfo/mixxx-devel" sourceforge_archive_link="http://sourceforge.net/mailarchive/forum.php?forum=mixxx-devel" gmane_archive_link="http://news.gmane.org/gmane.comp.multimedia.mixxx.devel" %}The <a href="{{ mailing_list_link}} ">mixxx-devel</a> mailing list (<a href="{{ sourceforge_archive_link }}">SourceForge</a> and <a href="{{ gmane_archive_link }}">Gmane</a> archives) is now a low traffic anouncment channel. Subscribe to this list, if you like to keep informed about new releases and other topics. {% endblocktrans %}
+      {% blocktrans with mailing_list_link="https://lists.sourceforge.net/lists/listinfo/mixxx-devel" sourceforge_archive_link="http://sourceforge.net/mailarchive/forum.php?forum=mixxx-devel" gmane_archive_link="http://news.gmane.org/gmane.comp.multimedia.mixxx.devel" %}The <a href="{{ mailing_list_link}} ">mixxx-devel</a> mailing list (<a href="{{ sourceforge_archive_link }}">SourceForge</a> and <a href="{{ gmane_archive_link }}">Gmane</a> archives) is now a low-traffic, mostly announcement channel. Subscribe if you would like to be informed about new releases and other topics. {% endblocktrans %}
     </p>
   </div>
 


### PR DESCRIPTION
I have changed the order in the support page by importance, re-added mixxx-devel and tweaked the Zulip text. The order is now like this 

###  **Community Support**
**Community Forums**  ................**Wiki**
**User Manual**  ............................**Zulip Chat** 
**Mailing List**  .............................**Bug Tracker** 

Unfortunately I was not able to test the webside. 

```
cactus build
cactus: Command not found

python -m cactus build
/usr/bin/python: No module named cactus.__main__; 'cactus' is a package and cannot be directly executed
```

I have a /home/daniel/.local/lib/python2.7/site-packages/cactus folder. 
What went wrong? 



