### PR TITLE
Replace references to IRC channel with Zulip chat

### DIFF
--- a/pages/get-involved.html
+++ b/pages/get-involved.html
@@ -37,7 +37,7 @@
       </li>
       <li>
         <p>
-          {% blocktrans with irc_channel_link="/irc/" %}When you're stuck, get help from our existing developers our IRC channel: #mixxx on <a href="{{ irc_channel_link }}">Freenode</a>{% endblocktrans %}
+          {% blocktrans with zulip_web_link="https://mixxx.zulipchat.com/" %}When you're stuck, get help from our existing developers on <a href="{{ zulip_web_link }}">Zulip chat</a>{% endblocktrans %}
         </p>
       </li>
       <li>
@@ -82,7 +82,7 @@
       </li>
       <li>
         <p>
-          {% blocktrans with forum_link="/forums/" freenode_link="http://www.freenode.net/" irc_channel_link="/irc/" %}Support other DJs with their technical questions on <a href="{{ forum_link }}">the forums</a> and <a href="{{ irc_channel_link }}">IRC channel</a>.{% endblocktrans %}
+          {% blocktrans with forum_link="/forums/" zulip_web_link="https://mixxx.zulipchat.com/" %}Support other DJs with their technical questions on <a href="{{ forum_link }}">the forums</a> and <a href="{{ zulip_web_link }}">Zulip</a>.{% endblocktrans %}
         </p>
       </li>
       <li>


### PR DESCRIPTION
IRC link is dead. Long live Zulip!