### PR TITLE
Remove links to google plus

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -15,9 +15,6 @@
          data-count="vertical">Tweet</a>
     </li>
     <li>
-      <g:plusone size="tall" href="http://www.mixxx.org"></g:plusone>
-    </li>
-    <li>
       <fb:like href="http://www.mixxx.org" send="false" layout="box_count" width="60" show_faces="false" style="position: relative; top: -4px;"></fb:like>
     </li>
   </ul>

--- a/templates/base.html
+++ b/templates/base.html
@@ -68,15 +68,6 @@
       !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
     </script>
 
-    <!-- G+ share button script -->
-    <script type="text/javascript">
-      (function() {
-        var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
-        po.src = 'https://apis.google.com/js/plusone.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
-      })();
-    </script>
-
     <script type="text/javascript">
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-3647499-1']);

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -4,9 +4,6 @@
   <div style="width: 440px; float: left;">
     <iframe src="http://www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.facebook.com%2Fpages%2FMIXXX-Digital-DJ%2F21723485212&amp;layout=standard&amp;show_faces=false&amp;width=440&amp;action=like&amp;colorscheme=dark&amp;height=24" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:440px; height:24px;" allowtransparency="true"></iframe>
   </div>
-  <div style="width: 440px; float: left;">
-    <g:plusone annotation="inline" href="http://www.mixxx.org"></g:plusone>
-  </div>
 
   <div style="clear: both;"></div>
 


### PR DESCRIPTION
Now that google is shutting down google+, it makes sense to remove the ability to share on the network as it encourages users to share to FB/Twitter instead.