### PR TITLE
Make website responsive

### DIFF
--- a/pages/features.html
+++ b/pages/features.html
@@ -32,7 +32,7 @@
     </p>
   </div>
   <div class="halfbox_right">
-    <img width="362px" src="{% static '/static/images/feature_deck.png' %}">
+    <img class="responsive" width="362px" src="{% static '/static/images/feature_deck.png' %}">
     <p><b>{% trans "Beat Rolls and Censor" %}</b><br>
       {% trans "Play with rhythm by triggering short loops and reverse-playback effects. The track stays in time so you don't miss a beat." %}
       {# TODO: Write a better way of explaining slip mode. #}
@@ -57,14 +57,14 @@
       {% trans "Load up to 64 sampler decks full of sounds to layer over your mix." %}{# TODO: Say more. #}
     </p>
 
-    <center><img src="{% static '/static/images/feature_sampler2.png' %}"></center>
+    <img class="center responsive" src="{% static '/static/images/feature_sampler2.png' %}">
     
     <h2>{% trans "Effects Chains" %}</h2>
     <p>
       {% trans "Link up to three effects in a chain for a unique twist on your mix. Fine tune your sound by tweaking each parameter individually. Customize your workflow by assigning different parameters to adjust with the effect's metaknob. Focus different effects from a controller for flexible control of effect chains, whether your controller has a full effects section or a single knob." %}
     </p>
 
-    <center><img src="{% static '/static/images/feature_effect_unit_expanded.png' %}"></center>
+    <img class="center responsive" src="{% static '/static/images/feature_effect_unit_expanded.png' %}">
   <div style="clear: both;"></div>
   
     <h1>{% trans "Customizable DJ Hardware Support" %}</h1>
@@ -72,7 +72,7 @@
     
     <div class="halfbox_left">
       <div style="height: 200px;">
-        <center><img width="340px" src="{% static '/static/images/feature_midi-2.0.png' %}" style="padding-top: 20px;"></center>
+        <img class="center responsive" width="340px" src="{% static '/static/images/feature_midi-2.0.png' %}" style="padding-top: 20px;">
       </div>
 
       <h2>{% trans "MIDI and HID Controller Support" %}</h2>
@@ -86,7 +86,7 @@
     </div>
     <div class="halfbox_right">
       <div style="height: 200px;">
-        <center><img src="{% static '/static/images/feature_vinylcontrol.png' %}"></center>
+        <img class="center responsive" src="{% static '/static/images/feature_vinylcontrol.png' %}">
       </div>
 
       <h2>{% trans "Free Timecode Vinyl Control" %}</h2>
@@ -124,7 +124,7 @@
       </p>
     </div>
     <div class="halfbox_right">
-      <img width="362px" src="{% static '/static/images/feature_library-2.0.png' %}" style="padding-top: 30px;">
+      <img class="responsive" width="362px" src="{% static '/static/images/feature_library-2.0.png' %}" style="padding-top: 30px;">
     </div>
 
     <div style="clear: both;"></div>
@@ -144,14 +144,13 @@
 
     <div class="gapfiller">
       <h1 style="margin-left: 30px;">{% trans "Choose Your Skin" %}</h1>
-      <center id="skin_screenshots">
-        <img width="445px" src="{% static '/static/images/feature_skins_deere.png' %}">
-        <img width="445px" src="{% static '/static/images/feature_skins_latenight.png' %}">
-        <img width="445px" src="{% static '/static/images/feature_skins_shade.png' %}">
-        <img width="445px" src="{% static '/static/images/feature_skins_tango.png' %}">
-
+      <div id="skin_screenshots" class="center">
+        <img class="responsive" width="445px" src="{% static '/static/images/feature_skins_deere.png' %}">
+        <img class="responsive" width="445px" src="{% static '/static/images/feature_skins_latenight.png' %}">
+        <img class="responsive" width="445px" src="{% static '/static/images/feature_skins_shade.png' %}">
+        <img class="responsive" width="445px" src="{% static '/static/images/feature_skins_tango.png' %}">
         <p>{% trans "Mixxx includes four different skins, each with a different look and a configurable layout" %}</p>
-      </center>
+      </div>
     </div>
 
     <!-- YouTube video

--- a/pages/features.html
+++ b/pages/features.html
@@ -202,9 +202,10 @@
       {% blocktrans with com_transifex_mixxxdj_link="https://www.transifex.com/organization/mixxx-dj-software" %} Use Mixxx in Spanish, Catalan, French, German, Italian, Russian, Finnish, Czech, Dutch, Polish, or Japanese... and more! See our <a href="{{ com_transifex_mixxxdj_link }}">Translation overview</a> page.{% endblocktrans %}
     </p>
     
-    <div class="gapfiller" style="height: 57px">
-      {% include "download_button.html" %}
+    <div class="gapfiller">
       <p style="text-align: center;">{% trans "Download Mixxx and start DJing now for FREE:" %}</p>
+      {% include "download_button.html" %}
+      <div style="clear: both;"></div>
     </div>
 </div>
 {% endblock %}

--- a/pages/features.html
+++ b/pages/features.html
@@ -51,160 +51,160 @@
     </p>
   </div>
   
-    <div style="clear: both;"></div>
-      <h2>{% trans "Sampler Decks" %}</h2>
-    <p>
-      {% trans "Load up to 64 sampler decks full of sounds to layer over your mix." %}{# TODO: Say more. #}
-    </p>
+  <div style="clear: both;"></div>
+  <h2>{% trans "Sampler Decks" %}</h2>
+  <p>
+    {% trans "Load up to 64 sampler decks full of sounds to layer over your mix." %}{# TODO: Say more. #}
+  </p>
 
-    <img class="center responsive" src="{% static '/static/images/feature_sampler2.png' %}">
+  <img class="center responsive" src="{% static '/static/images/feature_sampler2.png' %}">
     
-    <h2>{% trans "Effects Chains" %}</h2>
-    <p>
-      {% trans "Link up to three effects in a chain for a unique twist on your mix. Fine tune your sound by tweaking each parameter individually. Customize your workflow by assigning different parameters to adjust with the effect's metaknob. Focus different effects from a controller for flexible control of effect chains, whether your controller has a full effects section or a single knob." %}
-    </p>
+  <h2>{% trans "Effects Chains" %}</h2>
+  <p>
+    {% trans "Link up to three effects in a chain for a unique twist on your mix. Fine tune your sound by tweaking each parameter individually. Customize your workflow by assigning different parameters to adjust with the effect's metaknob. Focus different effects from a controller for flexible control of effect chains, whether your controller has a full effects section or a single knob." %}
+  </p>
 
-    <img class="center responsive" src="{% static '/static/images/feature_effect_unit_expanded.png' %}">
+  <img class="center responsive" src="{% static '/static/images/feature_effect_unit_expanded.png' %}">
   <div style="clear: both;"></div>
   
-    <h1>{% trans "Customizable DJ Hardware Support" %}</h1>
-    {% trans "Mixxx plays nice with a variety of hardware without artificial restrictions or exclusive vendor lock-ins. Use whatever gear you want to build your unique setup." %}{# TODO: Alignment somehow is messed up here. #}
-    
-    <div class="halfbox_left">
-      <div style="height: 200px;">
-        <img class="center responsive" width="340px" src="{% static '/static/images/feature_midi-2.0.png' %}" style="padding-top: 20px;">
-      </div>
+  <h1>{% trans "Customizable DJ Hardware Support" %}</h1>
+  {% trans "Mixxx plays nice with a variety of hardware without artificial restrictions or exclusive vendor lock-ins. Use whatever gear you want to build your unique setup." %}{# TODO: Alignment somehow is messed up here. #}
 
-      <h2>{% trans "MIDI and HID Controller Support" %}</h2>
-      <p>
-        {% blocktrans with hardware_compatibility_wiki_link="/wiki/doku.php/hardware_compatibility" %}<b>Included Presets</b><br> for controllers such as the Pioneer DDJ-SB2, Numark Mixtrack Pro 3, Allen &amp; Heath Xone K2, Hercules DJ Console Series, and many more. <a href="{{ hardware_compatibility_wiki_link }}">Full list of supported devices</a>{% endblocktrans %}
-      </p>
-
-      <p><b>{% trans "Programmable Mapping Engine" %}</b><br>
-        {% blocktrans with midi_scripting_wiki_link="/wiki/doku.php/midi_scripting" %}For creative tinkerers, controller mappings can be customized with the full flexibility of the JavaScript programming language. MIDI or HID messages can be mapped onto custom functions which execute complex behaviour. <a href="{{ midi_scripting_wiki_link }}">Read more</a>{% endblocktrans %}
-      </p>
+  <div class="halfbox_left">
+    <div style="height: 200px;">
+      <img class="center responsive" width="340px" src="{% static '/static/images/feature_midi-2.0.png' %}" style="padding-top: 20px;">
     </div>
-    <div class="halfbox_right">
-      <div style="height: 200px;">
-        <img class="center responsive" src="{% static '/static/images/feature_vinylcontrol.png' %}">
-      </div>
 
-      <h2>{% trans "Free Timecode Vinyl Control" %}</h2>
-      <p>
-        {% blocktrans with vinyl_control_manual_link="/manual/latest/chapters/vinyl_control.html" %}Control your digital music files from turntables or CDJs and a mixer using timecoded vinyl or CDs. Grab the music as if it was pressed onto wax and scratch to your heart's content. Mixxx is the only free timecode vinyl control software for Windows, macOS, and Linux. <a href="{{ vinyl_control_manual_link }}">Read more</a> {% endblocktrans %}
-      </p>
+    <h2>{% trans "MIDI and HID Controller Support" %}</h2>
+    <p>
+      {% blocktrans with hardware_compatibility_wiki_link="/wiki/doku.php/hardware_compatibility" %}<b>Included Presets</b><br> for controllers such as the Pioneer DDJ-SB2, Numark Mixtrack Pro 3, Allen &amp; Heath Xone K2, Hercules DJ Console Series, and many more. <a href="{{ hardware_compatibility_wiki_link }}">Full list of supported devices</a>{% endblocktrans %}
+    </p>
+
+    <p><b>{% trans "Programmable Mapping Engine" %}</b><br>
+      {% blocktrans with midi_scripting_wiki_link="/wiki/doku.php/midi_scripting" %}For creative tinkerers, controller mappings can be customized with the full flexibility of the JavaScript programming language. MIDI or HID messages can be mapped onto custom functions which execute complex behaviour. <a href="{{ midi_scripting_wiki_link }}">Read more</a>{% endblocktrans %}
+    </p>
+  </div>
+  <div class="halfbox_right">
+    <div style="height: 200px;">
+      <img class="center responsive" src="{% static '/static/images/feature_vinylcontrol.png' %}">
     </div>
+
+    <h2>{% trans "Free Timecode Vinyl Control" %}</h2>
+    <p>
+      {% blocktrans with vinyl_control_manual_link="/manual/latest/chapters/vinyl_control.html" %}Control your digital music files from turntables or CDJs and a mixer using timecoded vinyl or CDs. Grab the music as if it was pressed onto wax and scratch to your heart's content. Mixxx is the only free timecode vinyl control software for Windows, macOS, and Linux. <a href="{{ vinyl_control_manual_link }}">Read more</a> {% endblocktrans %}
+    </p>
+  </div>
 
   <div style="clear: both;"></div>
 
-    <h1>{% trans "Sophisticated Music Library" %}</h1>
-    <p>
-      {% trans "Designed by DJs, for DJs, Mixxx's music library helps organize your music so you can find the perfect next track to play. Powered by a high-performance database, searching your collection is intuitive and fast." %}
+  <h1>{% trans "Sophisticated Music Library" %}</h1>
+  <p>
+    {% trans "Designed by DJs, for DJs, Mixxx's music library helps organize your music so you can find the perfect next track to play. Powered by a high-performance database, searching your collection is intuitive and fast." %}
+  </p>
+
+  <div style="clear: both;"></div>
+
+  <div class="halfbox_left">
+    <h2><img src="{% static '/static/images/ic_library_itunes.png' %}" class="feature_icon">{% trans "Organization" %}</h2>
+    <p class="feature_indent">
+      <b>{% trans "Crates and Playlists" %}</b><br>
+      {% trans "Sort your music the way you want. Use playlists to plan your set and use crates to build your own categorization system." %}
     </p>
-
-    <div style="clear: both;"></div>
-
-    <div class="halfbox_left">
-      <h2><img src="{% static '/static/images/ic_library_itunes.png' %}" class="feature_icon">{% trans "Organization" %}</h2>
-      <p class="feature_indent">
-        <b>{% trans "Crates and Playlists" %}</b><br>
-        {% trans "Sort your music the way you want. Use playlists to plan your set and use crates to build your own categorization system." %}
-      </p>
-      <p class="feature_indent">
-        <b>{% trans "Search &amp; Sort" %}</b><br>
-        {% trans "Start typing to find the track you're thinking of, or narrow your search to a specific tag. Sort the library table hierarchically with multiple tags at a time." %}
-      </p>
-      <p class="feature_indent">
-        <b>{% trans "iTunes and Traktor Library Integration" %}</b><br>
-        {% trans "Drop fresh tracks from your iTunes or Traktor library right into your mix." %}
-      </p>
-      <p class="feature_indent">
-        <b>{% trans "MusicBrainz Tag Lookup" %}</b><br>
-        {% trans "Fingerprint your tracks and fetch missing tags from MusicBrainz." %}
-      </p>
-    </div>
-    <div class="halfbox_right">
-      <img class="responsive" width="362px" src="{% static '/static/images/feature_library-2.0.png' %}" style="padding-top: 30px;">
-    </div>
-
-    <div style="clear: both;"></div>
-
-    <div class="halfbox_left">
-      <h2><img src="{% static '/static/images/ic_library_prepare.png' %}" class="feature_icon">{% trans "BPM &amp; Key Detection" %}</h2>
-      <p class="feature_indent">{% trans "BPM detection finds the beat in even the toughest rhythms. Musical key detection helps identify tracks that are in harmony. Sort your library by BPM and key to quickly find tracks that will blend in seamlessly." %}</p>
-    </div>
-    <div class="halfbox_right">
-      <h2><img src="{% static '/static/images/ic_library_autodj.png' %}" class="feature_icon">{% trans "Auto DJ" %}</h2>
-      <p class="feature_indent">
-        {% trans "Need a break? Create a quick playlist and let Auto DJ take over. Automatic crossfading watches your back until you return." %}
-      </p>
-    </div>
-
-    <div style="clear: both;"></div>
-
-    <div class="gapfiller">
-      <h1 style="margin-left: 30px;">{% trans "Choose Your Skin" %}</h1>
-      <div id="skin_screenshots" class="center">
-        <img class="responsive" width="445px" src="{% static '/static/images/feature_skins_deere.png' %}">
-        <img class="responsive" width="445px" src="{% static '/static/images/feature_skins_latenight.png' %}">
-        <img class="responsive" width="445px" src="{% static '/static/images/feature_skins_shade.png' %}">
-        <img class="responsive" width="445px" src="{% static '/static/images/feature_skins_tango.png' %}">
-        <p>{% trans "Mixxx includes four different skins, each with a different look and a configurable layout" %}</p>
-      </div>
-    </div>
-
-    <!-- YouTube video
-    TODO: New video for 2.1
-    <div style="padding-bottom: 30px;">
-      <center>
-        <iframe width="640" height="360" src="http://www.youtube.com/embed/axlW5Q_8y6c?start=499&hd=1&modestbranding=0&rel=0&controls=1" frameborder="0" allowfullscreen></iframe>
-      </center>
-    </div> -->
-
-    <h1>{% trans "Record and Broadcast" %}</h1>
-    <p>
-      {% trans "Mixxx includes a number of recording and broadcasting features to help you share your mixes and spread your name." %}
+    <p class="feature_indent">
+      <b>{% trans "Search &amp; Sort" %}</b><br>
+      {% trans "Start typing to find the track you're thinking of, or narrow your search to a specific tag. Sort the library table hierarchically with multiple tags at a time." %}
     </p>
+    <p class="feature_indent">
+      <b>{% trans "iTunes and Traktor Library Integration" %}</b><br>
+      {% trans "Drop fresh tracks from your iTunes or Traktor library right into your mix." %}
+    </p>
+    <p class="feature_indent">
+      <b>{% trans "MusicBrainz Tag Lookup" %}</b><br>
+      {% trans "Fingerprint your tracks and fetch missing tags from MusicBrainz." %}
+    </p>
+  </div>
+  <div class="halfbox_right">
+    <img class="responsive" width="362px" src="{% static '/static/images/feature_library-2.0.png' %}" style="padding-top: 30px;">
+  </div>
+
+  <div style="clear: both;"></div>
+
+  <div class="halfbox_left">
+    <h2><img src="{% static '/static/images/ic_library_prepare.png' %}" class="feature_icon">{% trans "BPM &amp; Key Detection" %}</h2>
+    <p class="feature_indent">{% trans "BPM detection finds the beat in even the toughest rhythms. Musical key detection helps identify tracks that are in harmony. Sort your library by BPM and key to quickly find tracks that will blend in seamlessly." %}</p>
+  </div>
+  <div class="halfbox_right">
+    <h2><img src="{% static '/static/images/ic_library_autodj.png' %}" class="feature_icon">{% trans "Auto DJ" %}</h2>
+    <p class="feature_indent">
+      {% trans "Need a break? Create a quick playlist and let Auto DJ take over. Automatic crossfading watches your back until you return." %}
+    </p>
+  </div>
+
+  <div style="clear: both;"></div>
+
+  <div class="gapfiller">
+    <h1 style="margin-left: 30px;">{% trans "Choose Your Skin" %}</h1>
+    <div id="skin_screenshots" class="center">
+      <img class="responsive" width="445px" src="{% static '/static/images/feature_skins_deere.png' %}">
+      <img class="responsive" width="445px" src="{% static '/static/images/feature_skins_latenight.png' %}">
+      <img class="responsive" width="445px" src="{% static '/static/images/feature_skins_shade.png' %}">
+      <img class="responsive" width="445px" src="{% static '/static/images/feature_skins_tango.png' %}">
+      <p>{% trans "Mixxx includes four different skins, each with a different look and a configurable layout" %}</p>
+    </div>
+  </div>
+
+  <!-- YouTube video
+  TODO: New video for 2.1
+  <div style="padding-bottom: 30px;">
+    <center>
+      <iframe width="640" height="360" src="http://www.youtube.com/embed/axlW5Q_8y6c?start=499&hd=1&modestbranding=0&rel=0&controls=1" frameborder="0" allowfullscreen></iframe>
+    </center>
+  </div> -->
+
+  <h1>{% trans "Record and Broadcast" %}</h1>
+  <p>
+    {% trans "Mixxx includes a number of recording and broadcasting features to help you share your mixes and spread your name." %}
+  </p>
+  
+  <div style="clear: both;"></div>
+
+  <div class="halfbox_left">
+    <h2><img src="{% static '/static/images/ic_library_recordings.png' %}" class="feature_icon">Recording</h2>
+    <p>{% trans "Record your live mixes to the lossless WAV and FLAC formats or lossy Ogg Vorbis format, with MP3 recording enabled by the separate LAME library. Recordings are automatically archived in the library for fast access." %}
+    </p>
+  </div>
+  <div class="halfbox_right">
+    <h2><img src="{% static '/static/images/ic_preferences_broadcast.png' %}" class="feature_icon">{% trans "Live Broadcasting" %}</h2>
+    <p>
+      {% trans "Stream your mixes live over the Internet to your audience and friends through a Shoutcast or Icecast server." %}
+    </p>
+  </div>
+
+  <div style="clear: both;"></div>
+
+  <div class="halfbox_left">
+    <h2><img src="{% static '/static/images/ic_preferences_replaygain.png' %}" class="feature_icon">{% trans "ReplayGain Normalization" %}</h2>
+    <p>
+      {% trans "Song loudness is automatically adjusted when loading a deck so your mixes maintain a consistent volume. Mixxx reads existing ReplayGain tags and analyzes songs that don't have them." %}
+    </p>
+  </div>
+  <div class="halfbox_right">
+    <h2><img src="{% static '/static/images/ic_preferences_soundhardware.png' %}" class="feature_icon">{% trans "Microphone &amp; Auxiliary Inputs" %}</h2>
+    <p>
+      {% trans "Whether you're collaborating with a vocalist, giving shoutouts on the air, or improvising on your guitar, integrate live audio input into your mix. Four microphone inputs and four auxiliary inputs let you include different sound sources without needing an external hardware mixer. Latency compensation keeps your recorded and broadcasted mixes in time when using direct monitoring." %}
+    </p>
+  </div>
+
+  <div style="clear: both;"></div>
+  <h1>{% trans "Native Language Support" %}</h1>
+  <p>
+    {% blocktrans with com_transifex_mixxxdj_link="https://www.transifex.com/organization/mixxx-dj-software" %} Use Mixxx in Spanish, Catalan, French, German, Italian, Russian, Finnish, Czech, Dutch, Polish, or Japanese... and more! See our <a href="{{ com_transifex_mixxxdj_link }}">Translation overview</a> page.{% endblocktrans %}
+  </p>
     
+  <div class="gapfiller">
+    <p style="text-align: center;">{% trans "Download Mixxx and start DJing now for FREE:" %}</p>
+    {% include "download_button.html" %}
     <div style="clear: both;"></div>
-
-    <div class="halfbox_left">
-      <h2><img src="{% static '/static/images/ic_library_recordings.png' %}" class="feature_icon">Recording</h2>
-      <p>{% trans "Record your live mixes to the lossless WAV and FLAC formats or lossy Ogg Vorbis format, with MP3 recording enabled by the separate LAME library. Recordings are automatically archived in the library for fast access." %}
-      </p>
-    </div>
-    <div class="halfbox_right">
-      <h2><img src="{% static '/static/images/ic_preferences_broadcast.png' %}" class="feature_icon">{% trans "Live Broadcasting" %}</h2>
-      <p>
-        {% trans "Stream your mixes live over the Internet to your audience and friends through a Shoutcast or Icecast server." %}
-      </p>
-    </div>
-
-    <div style="clear: both;"></div>
-
-    <div class="halfbox_left">
-      <h2><img src="{% static '/static/images/ic_preferences_replaygain.png' %}" class="feature_icon">{% trans "ReplayGain Normalization" %}</h2>
-      <p>
-        {% trans "Song loudness is automatically adjusted when loading a deck so your mixes maintain a consistent volume. Mixxx reads existing ReplayGain tags and analyzes songs that don't have them." %}
-      </p>
-    </div>
-    <div class="halfbox_right">
-      <h2><img src="{% static '/static/images/ic_preferences_soundhardware.png' %}" class="feature_icon">{% trans "Microphone &amp; Auxiliary Inputs" %}</h2>
-      <p>
-        {% trans "Whether you're collaborating with a vocalist, giving shoutouts on the air, or improvising on your guitar, integrate live audio input into your mix. Four microphone inputs and four auxiliary inputs let you include different sound sources without needing an external hardware mixer. Latency compensation keeps your recorded and broadcasted mixes in time when using direct monitoring." %}
-      </p>
-    </div>
-
-    <div style="clear: both;"></div>
-    <h1>{% trans "Native Language Support" %}</h1>
-    <p>
-      {% blocktrans with com_transifex_mixxxdj_link="https://www.transifex.com/organization/mixxx-dj-software" %} Use Mixxx in Spanish, Catalan, French, German, Italian, Russian, Finnish, Czech, Dutch, Polish, or Japanese... and more! See our <a href="{{ com_transifex_mixxxdj_link }}">Translation overview</a> page.{% endblocktrans %}
-    </p>
-    
-    <div class="gapfiller">
-      <p style="text-align: center;">{% trans "Download Mixxx and start DJing now for FREE:" %}</p>
-      {% include "download_button.html" %}
-      <div style="clear: both;"></div>
-    </div>
+  </div>
 </div>
 {% endblock %}

--- a/pages/get-involved.html
+++ b/pages/get-involved.html
@@ -56,7 +56,7 @@
 
   <div class="gapfiller">
     <h3>{% trans "Development Cycle in a Nutshell" %}</h3>
-    <img src="{% static '/static/images/developmentcycle.png' %}" alt="{% trans "Mixxx Development Cycle" %}">
+    <img class="responsive" src="{% static '/static/images/developmentcycle.png' %}" alt="{% trans "Mixxx Development Cycle" %}">
   </div>
 
   <div class="halfbox_left">

--- a/pages/get-involved.html
+++ b/pages/get-involved.html
@@ -6,13 +6,12 @@
 
 {% block body %}
 <div class="content">
+  <h1 style="display:inline-block">{% trans "Get Involved" %}</h1>
   <div style="padding-top: 5px; float: right;">
-    <H2><a href="#djs">{% trans "Not a coder? Scroll down!" %}</a></H2>
+    <h2><a href="#djs">{% trans "Not a coder? Scroll down!" %}</a></h2>
   </div>
-
-  <H1>{% trans "Get Involved" %}</H1>
   <div class="halfbox_left">
-    <H2>{% trans "Software Developers" %}</H2>
+    <h2>{% trans "Software Developers" %}</h2>
     <p>
       {% blocktrans with qt_link="http://www.qt.io" %}Mixxx is written in C++ and uses the <a href="{{ qt_link }}">Qt</a> platform library for most data structures, graphics drawing, and window handling. Fortunately, Qt is easy to use and very well documented, <b>so you don't need any prior Qt or audio programming experience to start hacking on Mixxx</b>.{% endblocktrans %}
     </p>
@@ -23,7 +22,7 @@
   </div>
 
   <div class="halfbox_right">
-    <H3>{% trans "Start Developing Now" %}</H3>
+    <h3>{% trans "Start Developing Now" %}</h3>
     <ul>
       <li>
         <p>
@@ -56,13 +55,13 @@
   <div style="clear: both;"></div>
 
   <div class="gapfiller">
-    <H3>{% trans "Development Cycle in a Nutshell" %}</H3>
+    <h3>{% trans "Development Cycle in a Nutshell" %}</h3>
     <img src="{% static '/static/images/developmentcycle.png' %}" alt="{% trans "Mixxx Development Cycle" %}">
   </div>
 
   <div class="halfbox_left">
     <a name="djs"></a>
-    <H2>{% trans "DJs" %}</H2>
+    <h2>{% trans "DJs" %}</h2>
     {% trans "There are many ways to help out as a DJ:" %}
     <ul>
       <li>
@@ -100,7 +99,7 @@
 
   <a name="translators"></a>
   <div class="halfbox_right">
-    <H2>{% trans "Translators" %}</H2>
+    <h2>{% trans "Translators" %}</h2>
     <p>
       {% blocktrans %}We're pleased to offer Mixxx in many languages. Our translations are entirely community provided, so we need your help to spread Mixxx with translations into more languages, as well as to update and ensure the accuracy of existing translations.{% endblocktrans %}
     </p>
@@ -110,7 +109,7 @@
   </div>
 
   <div class="halfbox_right">
-    <H2>{% trans "Graphic Artists" %}</H2>
+    <h2>{% trans "Graphic Artists" %}</h2>
     <ul>
       <li>
         <p>

--- a/pages/index.html
+++ b/pages/index.html
@@ -28,6 +28,7 @@
 
 {% block body %}
 <div class="gapfiller" style="margin-bottom: 0px;">
+  <p>Free and open source DJ software for Windows, macOS, and Linux</p>
   {% include "download_button.html" %}
 
         <!--
@@ -51,7 +52,6 @@
     <div style="float: right; margin-top: 16px; padding-right: 8px;">
         <img src="{% static '/static/images/squiggle.png' %}">
     </div>-->
-  <p style="text-align: center;">Free and open source DJ software for Windows, macOS, and Linux</p>
   <div style="clear: both;"></div>
 </div> <!-- gapfiller -->
 
@@ -93,11 +93,12 @@
 
   <div style="clear: both;"></div>
 
-  <div class="gapfiller" style="height: 57px;">
-    {% include "download_button.html" %}
-    <p style="text-align: center;">
+  <div class="gapfiller">
+    <p>
       {% blocktrans with features_link="/features" %}See <a href="{{ features_link }}">dozens more features</a> or start downloading Mixxx for free now:{% endblocktrans %}
     </p>
+    {% include "download_button.html" %}
+    <div style="clear: both;"></div>
   </div>
 
   <h1>{% trans "Friendly Community" %}</h1>

--- a/pages/index.html
+++ b/pages/index.html
@@ -30,28 +30,6 @@
 <div class="gapfiller" style="margin-bottom: 0px;">
   <p>Free and open source DJ software for Windows, macOS, and Linux</p>
   {% include "download_button.html" %}
-
-        <!--
-        <div style="padding-left: 24px; width: 192px;">
-        <p>Download FREE for <script type="text/javascript"> document.write(OSName); </script> </p>
-        </div>
-        -->
-	<!-- Deactivate linking to outdated MAS version 10/6/13 8:26 AM //jus
-    <div style="float: right; margin-top: 0px; margin-right: -14px;">
-        <script type="text/javascript">
-            if (OSName.search("OS X") >= 0) {
-                document.write('<a href="http://itunes.apple.com/us/app/mixxx/id413756578?mt=12&ls=1"><img src="{% static '/static/images/available-on-mac-app-store-frontpage.png' %}" ></a><br>');
-            } else
-            {
-                document.write("<p><small>Download FREE for " + OSName + "</small></p>");
-            }
-            </script>
-    </div>
- 	-->
-    <!--
-    <div style="float: right; margin-top: 16px; padding-right: 8px;">
-        <img src="{% static '/static/images/squiggle.png' %}">
-    </div>-->
   <div style="clear: both;"></div>
 </div> <!-- gapfiller -->
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -22,7 +22,7 @@
 
 <div id="splash">
   <h1>{% trans "DJ Your Way" %}</h1>
-  <img class="background" width="676" height="380" src="{% static '/static/images/splash-2.1.png' %}">
+  <img class="center responsive" src="{% static '/static/images/splash-2.1.png' %}">
 </div>
 {% endblock %}
 
@@ -90,7 +90,7 @@
 
   <div id="achievements">
     <div class="achievement" style="width: 180px;">
-      <img src="{% static '/static/images/rating_macappstore.png' %}" alt="#1" style="padding-top: 0px;">
+      <img class="responsive" src="{% static '/static/images/rating_macappstore.png' %}" alt="#1" style="padding-top: 0px;">
       <br>
       {% trans "#1 Top Free Mac App Worldwide" %}<br>
       Mac App Store<br>
@@ -98,17 +98,17 @@
     </div>
 
     <div class="achievement" style="margin-top: 10px;">
-      <img src="{% static '/static/images/rating_cnet.png' %}" alt="CNet">
+      <img class="responsive" src="{% static '/static/images/rating_cnet.png' %}" alt="CNet">
     </div>
 
     <div class="achievement" style="margin-top: 30px;">
-      <img src="{% static '/static/images/rating_cm.png' %}" alt="Computer Music"><br>
+      <img class="responsive" src="{% static '/static/images/rating_cm.png' %}" alt="Computer Music"><br>
       {% trans "Free Pick of the Month" %}<br>
       <small>{% trans "September 2007" %}</small>
     </div>
 
     <div class="achievement" style="margin-top: 50px">
-      <img src="{% static '/static/images/rating_synthtopia.png' %}" alt="Synthtopia">
+      <img class="responsive" src="{% static '/static/images/rating_synthtopia.png' %}" alt="Synthtopia">
       <br>
       {% trans '"The coolest open source<br>application ever?"' %}<br>
       <small>{% trans "February 2011" %}</small>

--- a/pages/index.html
+++ b/pages/index.html
@@ -15,9 +15,6 @@
          data-count="vertical">Tweet</a>
     </li>
     <li>
-      <g:plusone size="tall" href="http://www.mixxx.org"></g:plusone>
-    </li>
-    <li>
       <fb:like href="http://www.mixxx.org" send="false" layout="box_count" width="60" show_faces="false" style="position: relative; top: -4px;"></fb:like>
     </li>
   </ul>

--- a/pages/press.html
+++ b/pages/press.html
@@ -46,9 +46,7 @@
 
   <h2>{% trans "Artwork" %}</h2>
   <br/>
-  <center>
-    <img src="{% static '/static/images/press_art/logocolour_nopadding_small.png' %}">
-  </center>
+  <img class="center" src="{% static '/static/images/press_art/logocolour_nopadding_small.png' %}">
   <br/>
 
   <p style="text-indent: 0px;">

--- a/pages/whats-new-in-mixxx-1-11.html
+++ b/pages/whats-new-in-mixxx-1-11.html
@@ -8,11 +8,11 @@
 <div class="content">
 
   <div style="float: right; width: 370px; border: 1px solid #222; border-radius: 5px; margin-top: 0px; padding: 16px; margin-left: 70px; margin-right: 20px;">
-    <H2 style="margin-top: 0px;">{% trans "New to Mixxx?" %}</H2>
+    <h2 style="margin-top: 0px;">{% trans "New to Mixxx?" %}</h2>
     {% blocktrans %}Mixxx is <b>free</b>, open source DJ software that gives you everything you need to DJ and mix music live at your next party or club gig. <a href="/download">Download it today</a> and mix like a pro on Windows, Mac OS X, and Linux.{% endblocktrans %}
   </div>
 
-  <H1>{% trans "What's New in Mixxx 1.11?" %}</H1>
+  <h1>{% trans "What's New in Mixxx 1.11?" %}</h1>
   <p>
     {% trans "Take your DJing to the next level. Mixxx 1.11 adds dozens of powerful new features for the pro DJ. And as always, Mixxx 1.11 is available as a <b>free upgrade</b> for all existing Mixxx users." %}
   </p>
@@ -21,7 +21,7 @@
   <img class="center responsive" width="880" style="margin-top: 50px; margin-bottom: 50px;" src="{% static '/static/images/mixxx_tilt.png' %}">
 
   <div class="halfbox_left">
-    <H2>{% trans "Vibrant Waveforms" %}</H2>
+    <h2>{% trans "Vibrant Waveforms" %}</h2>
     <p>
       {% trans "Visualize the dynamics of every beat with the brand new triple-band color waveforms in Mixxx 1.11. Watch each band morph as you tweak each EQ." %}
     </p>
@@ -40,7 +40,7 @@
     <img class="responsive" src="{% static '/static/images/feature_beatdetection.png' %}">
   </div>
   <div class="halfbox_right">
-    <H2>{% trans "Next Generation Beat Detection" %}</H2>
+    <h2>{% trans "Next Generation Beat Detection" %}</h2>
     <p>
       {% trans "Sync, drop loops, and lay hotcues with deadly accuracy. A cutting-edge beat detection engine from Queen Mary University delivers <b>unrivaled precision</b> in detecting song tempos and individual beats." %}
     </p>
@@ -51,7 +51,7 @@
   <div style="clear: both;"></div>
 
   <div class="halfbox_left">
-    <H2>{% trans "Session History" %}</H2>
+    <h2>{% trans "Session History" %}</h2>
     <p>
       {% trans "Whether you need to report your setlists to ASCAP or just remember the tracks you played last night, the new Session History feature keeps track of every tune you drop so that you don't have to." %}
     </p>
@@ -67,7 +67,7 @@
   </div>
 
   <div class="halfbox_right">
-    <H2>{% trans "Preview Deck" %}</H2>
+    <h2>{% trans "Preview Deck" %}</h2>
     <p>
       {% trans "Never skip a beat - A dedicated deck for track previewing is now directly integrated into the library and routed to your headphones." %}
     </p>
@@ -75,7 +75,7 @@
   <div style="clear: both;"></div>
 
   <div class="halfbox_left">
-    <H2>{% trans "Beatloop Rolls" %}</H2>
+    <h2>{% trans "Beatloop Rolls" %}</h2>
     <p>
       {% trans "Mash and stutter your mix with Beatloop Rolls. This stunning new effect works just like a beatloop except when you release the button the decks jumps to where it would have been as if you hadn't started the loop. Tryout by right-clicking on a beat-loop button." %}
     </p>
@@ -93,7 +93,7 @@
   <div style="clear: both;"></div>
 
   <div class="halfbox_left">
-    <H2>{% trans "Upgraded Sample Decks" %}</H2>
+    <h2>{% trans "Upgraded Sample Decks" %}</h2>
     <p>
       {% trans "All sample decks now have sync buttons for automatic tempo and phase sychronization with the main decks." %}
     </p>
@@ -101,7 +101,7 @@
   </div>
 
   <div class="halfbox_right">
-    <H2>{% trans "Core Mixing Engine Improvements" %}</H2>
+    <h2>{% trans "Core Mixing Engine Improvements" %}</h2>
     <ul>
       <li>{% trans "Improved waveform scratching" %}</li>
       <li>{% trans "Hamster (reverse) crossfader option" %}</li>
@@ -114,7 +114,7 @@
   <div style="clear: both;"></div>
 
   <div class="halfbox_left">
-    <H2>New Sample Grid Skin</H2>
+    <h2>New Sample Grid Skin</h2>
   </div>
   <div style="text-align: center; margin-bottom: 100px;">
     <img class="responsive" src="{% static '/static/images/feature_samplegrid.png' %}">
@@ -124,13 +124,13 @@
   </div>
   <div style="clear: both;"></div>
 
-  <H1>{% trans "Upgraded Library" %}</H1>
+  <h1>{% trans "Upgraded Library" %}</h1>
 
   {% trans "The Mixxx music library was designed from the ground up for DJs. Powered by a high-performance database, accessing and organizing your music is easy and intuitive." %}
   <div style="clear: both;"></div>
 
   <div class="halfbox_left">
-    <H2><img src="{% static '/static/images/ic_library_itunes.png' %}" class="feature_icon">{% trans "Advanced Search" %}</H2>
+    <h2><img src="{% static '/static/images/ic_library_itunes.png' %}" class="feature_icon">{% trans "Advanced Search" %}</h2>
     <p class="feature_indent"></p>
 
     {% trans "The library search box is now capable of advanced queries to help you pinpoint that perfect track." %}
@@ -171,13 +171,13 @@
   </div>
   <div style="clear: both;"></div>
 
-  <H1>{% trans "Improved, Expanded Support for DJ Controllers" %}</H1>
+  <h1>{% trans "Improved, Expanded Support for DJ Controllers" %}</h1>
   <p>
     {% trans "Mixxx 1.11 brings support for an exciting new range of DJ controllers and a new point and click MIDI mapping interface that makes it easier to create and customize the way your controller works with Mixxx." %}
   </p>
 
   <div class="halfbox_left">
-    <H2>{% trans "USB HID and USB Bulk Mode DJ Controller Support" %}</H2>
+    <h2>{% trans "USB HID and USB Bulk Mode DJ Controller Support" %}</h2>
     <p>
       {% trans "Mixxx now supports non-MIDI devices using its powerful scripting system. Mixxx 1.11.0 comes with HID presets for the following devices:" %}
       <ul>
@@ -194,14 +194,14 @@
   </div>
 
   <div class="halfbox_right">
-    <H2>{% trans "Point and Click MIDI Mapping" %}</H2>
+    <h2>{% trans "Point and Click MIDI Mapping" %}</h2>
     <p>
       {% trans "Getting your controller mapped is now easier than ever. Just click on the  button or knob you want to map in Mixxx and then wiggle the control on your MIDI controller to wire it up." %}
     </p>
   </div>
   <div style="clear: both;"></div>
 
-  <H2>{% trans "Newly Supported DJ MIDI Controllers" %}</H2>
+  <h2>{% trans "Newly Supported DJ MIDI Controllers" %}</h2>
   <div style="float: right">
     <img class="responsive" src="{% static '/static/images/feature_newcontrollers.png' %}" alt="Newly Supported Controllers in Mixxx 1.11">
   </div>

--- a/pages/whats-new-in-mixxx-1-11.html
+++ b/pages/whats-new-in-mixxx-1-11.html
@@ -88,9 +88,9 @@
   </div>
   <div style="clear: both;"></div>
 
-  <div class="gapfiller" style="height: 57px; margin-top: 60px;">
-    {% include "download_button.html" %}
+  <div class="gapfiller">
     <p style="text-align: center;">{% trans "Like what you see? Download Mixxx for FREE and Start DJing:" %}</p>
+    {% include "download_button.html" %}
   </div>
   <div style="clear: both;"></div>
 
@@ -270,9 +270,10 @@
 
   <div style="clear: both;"></div>
 
-  <div class="gapfiller" style="height: 57px; margin-top: 60px; margin-bottom: 60px;">
-    {% include "download_button.html" %}
+  <div class="gapfiller">
     <p style="text-align: center;">{% trans "Ready to Upgrade? Download Mixxx for FREE and Start DJing:" %}</p>
+    {% include "download_button.html" %}
+    <div style="clear: both;"></div>
   </div>
 </div>
 {% endblock %}

--- a/pages/whats-new-in-mixxx-1-11.html
+++ b/pages/whats-new-in-mixxx-1-11.html
@@ -18,9 +18,7 @@
   </p>
   <div style="clear: both;"></div>
 
-  <div style="text-align: center; margin-top: 50px; margin-bottom: 50px;">
-    <img src="{% static '/static/images/mixxx_tilt.png' %}" height=300>
-  </div>
+  <img class="center responsive" width="880" style="margin-top: 50px; margin-bottom: 50px;" src="{% static '/static/images/mixxx_tilt.png' %}">
 
   <div class="halfbox_left">
     <H2>{% trans "Vibrant Waveforms" %}</H2>
@@ -33,13 +31,13 @@
   </div>
 
   <div class="halfbox_right">
-    <img src="{% static '/static/images/feature_vibrantwaveform.png' %}" style="margin-left: 30px;">
+    <img class="responsive" src="{% static '/static/images/feature_vibrantwaveform.png' %}" style="margin-left: 30px;">
   </div>
 
   <div style="clear: both;"></div>
 
   <div class="halfbox_left">
-    <img src="{% static '/static/images/feature_beatdetection.png' %}">
+    <img class="responsive" src="{% static '/static/images/feature_beatdetection.png' %}">
   </div>
   <div class="halfbox_right">
     <H2>{% trans "Next Generation Beat Detection" %}</H2>
@@ -60,12 +58,12 @@
   </div>
 
   <div class="halfbox_right">
-    <img src="{% static '/static/images/feature_sessionhistory.png' %}">
+    <img class="responsive" src="{% static '/static/images/feature_sessionhistory.png' %}">
   </div>
   <div style="clear: both;"></div>
 
   <div class="halfbox_left">
-    <img src="{% static '/static/images/feature_previewdeck.png' %}" style="margin-left: 60px;">
+    <img class="responsive" src="{% static '/static/images/feature_previewdeck.png' %}" style="margin-left: 60px;">
   </div>
 
   <div class="halfbox_right">
@@ -84,7 +82,7 @@
   </div>
 
   <div class="halfbox_right" style="margin-top: 30px;">
-    <img src="{% static '/static/images/feature_beatlooprolls.png' %}">
+    <img class="responsive" src="{% static '/static/images/feature_beatlooprolls.png' %}">
   </div>
   <div style="clear: both;"></div>
 
@@ -99,7 +97,7 @@
     <p>
       {% trans "All sample decks now have sync buttons for automatic tempo and phase sychronization with the main decks." %}
     </p>
-    <img src="{% static '/static/images/feature_samplerdeck.png' %}">
+    <img class="responsive" src="{% static '/static/images/feature_samplerdeck.png' %}">
   </div>
 
   <div class="halfbox_right">
@@ -119,7 +117,7 @@
     <H2>New Sample Grid Skin</H2>
   </div>
   <div style="text-align: center; margin-bottom: 100px;">
-    <img src="{% static '/static/images/feature_samplegrid.png' %}">
+    <img class="responsive" src="{% static '/static/images/feature_samplegrid.png' %}">
     <p>
       {% trans "With 16 sample decks, this skin is perfect for radio DJs and advanced beat-jugglers alike." %}
     </p>
@@ -155,7 +153,7 @@
   </div>
 
   <div class="halfbox_right">
-    <img src="{% static '/static/images/feature_library.png' %}" style="padding-top: 30px;">
+    <img class="responsive" src="{% static '/static/images/feature_library.png' %}" style="padding-top: 30px;">
     <b>{% trans "Exportable Set Lists" %}</b>
     <p>
       {% trans "Set playlists can now be exported as text files, CUE files, and M3U playlists." %}
@@ -205,7 +203,7 @@
 
   <H2>{% trans "Newly Supported DJ MIDI Controllers" %}</H2>
   <div style="float: right">
-    <img src="{% static '/static/images/feature_newcontrollers.png' %}" alt="Newly Supported Controllers in Mixxx 1.11">
+    <img class="responsive" src="{% static '/static/images/feature_newcontrollers.png' %}" alt="Newly Supported Controllers in Mixxx 1.11">
   </div>
 
   <p>
@@ -266,12 +264,12 @@
     {% blocktrans %}<b>Want to know if your DJ MIDI controller is supported in Mixxx?</b> Please check the <a href="/features/#full_specs">full technical specifications</a>.{% endblocktrans %}
   </div>
 
-  <center><img src="{% static '/static/images/feature_sampler2.png' %}"></center>
+  <img class="center responsive" src="{% static '/static/images/feature_sampler2.png' %}">
 
   <div style="clear: both;"></div>
 
   <div class="gapfiller">
-    <p style="text-align: center;">{% trans "Ready to Upgrade? Download Mixxx for FREE and Start DJing:" %}</p>
+    <p class="center">{% trans "Ready to Upgrade? Download Mixxx for FREE and Start DJing:" %}</p>
     {% include "download_button.html" %}
     <div style="clear: both;"></div>
   </div>

--- a/pages/whats-new-in-mixxx-2-0.html
+++ b/pages/whats-new-in-mixxx-2-0.html
@@ -8,11 +8,11 @@
 <div class="content">
 
   <div style="float: right; width: 370px; border: 1px solid #222; border-radius: 5px; margin-top: 0px; padding: 16px; margin-left: 70px; margin-right: 20px;">
-    <H2 style="margin-top: 0px;">{% trans "New to Mixxx?" %}</H2>
+    <h2 style="margin-top: 0px;">{% trans "New to Mixxx?" %}</h2>
     {% blocktrans %}Mixxx is <b>free</b>, open source DJ software that gives you everything you need to DJ and mix music live at your next party or club gig. <a href="/download">Download it today</a> and mix like a pro on Windows, Mac OS X, and Linux.{% endblocktrans %}
   </div>
 
-  <H1>{% trans "What's New in Mixxx 2.0?" %}</H1>
+  <h1>{% trans "What's New in Mixxx 2.0?" %}</h1>
   <p>
     {% trans "Three years in the making, we've added so many new features to Mixxx that we had to call it 2.0. As always, Mixxx 2.0 is available as a <b>free upgrade</b> for all existing Mixxx users." %}
   </p>
@@ -22,7 +22,7 @@
 
   <!-- Resizable Skins -->
   <div class="halfbox_left">
-    <H2>{% trans "Dynamic, Resizable Skins" %}</H2>
+    <h2>{% trans "Dynamic, Resizable Skins" %}</h2>
     <p>
       {% trans "Each of our three professionally-designed skins can stretch to fill whatever size screen you have.  Turn parts of the interface on and off to reveal the features you use most." %}
     </p>
@@ -38,7 +38,7 @@
     <img class="responsive" width="255px" src="{% static '/static/images/feature_mastersync-2.0.png' %}">
   </div>
   <div class="halfbox_right">
-    <H2>{% trans "4 Decks with Master Sync" %}</H2>
+    <h2>{% trans "4 Decks with Master Sync" %}</h2>
     <p>
       {% trans "Supporting the latest DJing techniques, Mixxx supports up to four decks playing back simultaneously.  Combine tracks with loops and samples to create sophisticated on-the-fly remixes." %}
     </p>
@@ -50,7 +50,7 @@
 
   <!-- Effects -->
   <div class="halfbox_left">
-    <H2>{% trans "Built-in Effects" %}</H2>
+    <h2>{% trans "Built-in Effects" %}</h2>
     <p>
       {% trans "Mixxx's new effect processing system allows you to apply up to 4 chains of effects to any mixer channel." %}
       {% trans "Mixxx 2.0 comes with 5 high-quality effects and 4 equalizer effects with many more to come!" %}
@@ -79,7 +79,7 @@
   </div>
 
   <div class="halfbox_right">
-    <H2>{% trans "Harmonic Mixing with Musical Key Detection" %}</H2>
+    <h2>{% trans "Harmonic Mixing with Musical Key Detection" %}</h2>
     <p>
       {% trans "Mixxx now detects the musical key of your tracks and allows you to fine tune them to be in key with the rest of your mix. With support for Traditional, Open Key, Lancelot, and custom key notations, you'll feel right at home no matter what system you're used to." %}
     </p>
@@ -88,7 +88,7 @@
 
   <!-- RGB Waveforms -->
   <div class="halfbox_left">
-    <H2>{% trans "RGB Waveforms" %}</H2>
+    <h2>{% trans "RGB Waveforms" %}</h2>
     <p>
       {% trans "See the sound of your music.  With RGB waveforms, bright red means killer bass, blue glints where you find crisp hihats, and soft greens show you when the lyrics come in.  A quick glance at the waveform overview and you'll know if a track is banging or just right for sunrise." %}
     </p>
@@ -106,7 +106,7 @@
   </div>
 
   <div class="halfbox_right">
-    <H2>{% trans "Four Microphones, Four AUX Inputs, Microphone Ducking" %}</H2>
+    <h2>{% trans "Four Microphones, Four AUX Inputs, Microphone Ducking" %}</h2>
     <p>
       {% trans "Radio DJs, MCs, and users with external gear will appreciate the flexibility of 12 total external audio inputs.  And with auto-ducking, listeners will always be able to hear you over the music." %}
     </p>
@@ -115,7 +115,7 @@
 
   <!-- Vinyl Passthrough -->
   <div class="halfbox_left">
-    <H2>{% trans "Vinyl Passthrough" %}</H2>
+    <h2>{% trans "Vinyl Passthrough" %}</h2>
     <p>
       {% trans "Calling all vinyl addicts &mdash; you can now switch off between vinyl timecode records and vinyl audio records with the new vinyl passthrough feature." %}
     </p>
@@ -134,7 +134,7 @@
 
   <!-- Cover Art -->
   <div class="halfbox_left">
-    <H2>{% trans "Cover Art Support" %}</H2>
+    <h2>{% trans "Cover Art Support" %}</h2>
     <p>
       {% trans "Mixxx reads cover art from your tracks and displays it in the library, on your decks, and on the spinning vinyl widgets." %}
     </p>
@@ -143,7 +143,7 @@
 
   <!-- Engine Improvements -->
   <div class="halfbox_right">
-    <H2>{% trans "Core Mixing Engine Improvements" %}</H2>
+    <h2>{% trans "Core Mixing Engine Improvements" %}</h2>
     <ul>
       <li>{% trans "Improved, high-fidelity equalizers." %}</li>
       <li>{% trans "Improved time-stretching algorithm for better sounding key-lock." %}</li>
@@ -160,7 +160,7 @@
   <div style="clear: both;"></div>
 
   <!-- Library -->
-  <H1>{% trans "Upgraded Library" %}</H1>
+  <h1>{% trans "Upgraded Library" %}</h1>
 
   {% trans "The Mixxx music library was designed from the ground up for DJs. Powered by a high-performance database, accessing and organizing your music is easy and intuitive." %}
   <div style="clear: both;"></div>
@@ -198,12 +198,12 @@
   <div style="clear: both;"></div>
 
   <!-- Controller Support -->
-  <H1>{% trans "Improved, Expanded Support for DJ Controllers" %}</H1>
+  <h1>{% trans "Improved, Expanded Support for DJ Controllers" %}</h1>
   <p>
     {% trans "Thanks to generous DJs and our vibrant forum community, Mixxx 2.0 brings support for an exciting new range of DJ controllers." %}
   </p>
 
-  <H2>{% trans "Newly Supported DJ Controllers" %}</H2>
+  <h2>{% trans "Newly Supported DJ Controllers" %}</h2>
   <div style="float: right">
     <img class="responsive" width="500px" src="{% static '/static/images/feature_newcontrollers-2.0.jpg' %}" alt="Newly Supported Controllers in Mixxx 2.0">
   </div>

--- a/pages/whats-new-in-mixxx-2-0.html
+++ b/pages/whats-new-in-mixxx-2-0.html
@@ -128,9 +128,9 @@
   <div style="clear: both;"></div>
 
   <!-- Quit readin' and download already! -->
-  <div class="gapfiller" style="height: 57px; margin-top: 60px;">
-    {% include "download_button.html" %}
+  <div class="gapfiller">
     <p style="text-align: center;">{% trans "Like what you see? Download Mixxx for FREE and Start DJing:" %}</p>
+    {% include "download_button.html" %}
   </div>
   <div style="clear: both;"></div>
 
@@ -248,9 +248,10 @@
   </div>
   <div style="clear: both;"></div>
 
-  <div class="gapfiller" style="height: 57px; margin-top: 60px; margin-bottom: 60px;">
-    {% include "download_button.html" %}
+  <div class="gapfiller">
     <p style="text-align: center;">{% trans "Ready to Upgrade? Download Mixxx for FREE and Start DJing:" %}</p>
+    {% include "download_button.html" %}
+    <div style="clear: both;"></div>
   </div>
 </div>
 {% endblock %}

--- a/pages/whats-new-in-mixxx-2-0.html
+++ b/pages/whats-new-in-mixxx-2-0.html
@@ -18,9 +18,7 @@
   </p>
   <div style="clear: both;"></div>
 
-  <div style="text-align: center; margin-top: 50px; margin-bottom: 50px;">
-    <img src="{% static '/static/images/mixxx_tilt-2.0.jpg' %}" height=300>
-  </div>
+  <img class="center responsive" src="{% static '/static/images/mixxx_tilt-2.0.jpg' %}" width="879" style="margin-top: 50px; margin-bottom: 50px;">
 
   <!-- Resizable Skins -->
   <div class="halfbox_left">
@@ -31,13 +29,13 @@
   </div>
 
   <div class="halfbox_right">
-    <img width="400px" src="{% static '/static/images/feature_resizeableskins-2.0.jpg' %}" style="margin-left: 30px;">
+    <img class="responsive" width="400px" src="{% static '/static/images/feature_resizeableskins-2.0.jpg' %}" style="margin-left: 30px;">
   </div>
   <div style="clear: both;"></div>
 
   <!-- 4 Decks, Master Sync -->
   <div class="halfbox_left">
-    <img width="255px" src="{% static '/static/images/feature_mastersync-2.0.png' %}">
+    <img class="responsive" width="255px" src="{% static '/static/images/feature_mastersync-2.0.png' %}">
   </div>
   <div class="halfbox_right">
     <H2>{% trans "4 Decks with Master Sync" %}</H2>
@@ -71,13 +69,13 @@
   </div>
 
   <div class="halfbox_right">
-    <img width="400px" src="{% static '/static/images/feature_effects-2.0.png' %}">
+    <img class="responsive" width="400px" src="{% static '/static/images/feature_effects-2.0.png' %}">
   </div>
   <div style="clear: both;"></div>
 
   <!-- Harmonic Mixing / Key Detection -->
   <div class="halfbox_left">
-    <img width="300px" src="{% static '/static/images/feature_keydetect-2.0.jpg' %}" style="margin-left: 60px;">
+    <img class="responsive" width="300px" src="{% static '/static/images/feature_keydetect-2.0.jpg' %}" style="margin-left: 60px;">
   </div>
 
   <div class="halfbox_right">
@@ -97,14 +95,14 @@
   </div>
 
   <div class="halfbox_right" style="margin-top: 30px;">
-    <img width="400px" src="{% static '/static/images/feature_rgbwaveform-2.0.png' %}">
+    <img class="responsive" width="400px" src="{% static '/static/images/feature_rgbwaveform-2.0.png' %}">
   </div>
 
   <div style="clear: both;"></div>
 
   <!-- 4 Mic / 4 Aux Inputs -->
   <div class="halfbox_left" style="margin-top: 30px;">
-    <img width="400px" src="{% static '/static/images/feature_inputs-2.0.png' %}">
+    <img class="responsive" width="400px" src="{% static '/static/images/feature_inputs-2.0.png' %}">
   </div>
 
   <div class="halfbox_right">
@@ -123,7 +121,7 @@
     </p>
   </div>
   <div class="halfbox_right" style="margin-top: 30px;">
-    <img width="255px" src="{% static '/static/images/feature_vinylpassthrough-2.0.png' %}">
+    <img class="responsive" width="255px" src="{% static '/static/images/feature_vinylpassthrough-2.0.png' %}">
   </div>
   <div style="clear: both;"></div>
 
@@ -140,7 +138,7 @@
     <p>
       {% trans "Mixxx reads cover art from your tracks and displays it in the library, on your decks, and on the spinning vinyl widgets." %}
     </p>
-    <img width="350px" src="{% static '/static/images/feature_coverart-2.0.png' %}">
+    <img class="responsive" width="350px" src="{% static '/static/images/feature_coverart-2.0.png' %}">
   </div>
 
   <!-- Engine Improvements -->
@@ -168,7 +166,7 @@
   <div style="clear: both;"></div>
 
   <div class="halfbox_left">
-    <img width="360px" src="{% static '/static/images/feature_library-2.0.jpg' %}" style="margin-left: 60px;">
+    <img class="responsive" width="360px" src="{% static '/static/images/feature_library-2.0.jpg' %}" style="margin-left: 60px;">
   </div>
 
   <div class="halfbox_right">
@@ -207,7 +205,7 @@
 
   <H2>{% trans "Newly Supported DJ Controllers" %}</H2>
   <div style="float: right">
-    <img width="500px" src="{% static '/static/images/feature_newcontrollers-2.0.jpg' %}" alt="Newly Supported Controllers in Mixxx 2.0">
+    <img class="responsive" width="500px" src="{% static '/static/images/feature_newcontrollers-2.0.jpg' %}" alt="Newly Supported Controllers in Mixxx 2.0">
   </div>
 
   <p>

--- a/plugins/page_context.py
+++ b/plugins/page_context.py
@@ -12,13 +12,13 @@ def preBuildPage(page, context, data):
         ("/download.html", "big", "Download", "Navigation bar link to Mixxx download page."),
         ("/features.html", "big", "Features", "Navigation bar link to Mixxx features page."),
         ("/support.html", "big", "Support & Community", "Navigation bar link to Mixxx support page."),
-        ( "/manual/latest", "medium", "Manual", "Navigation bar link to Mixxx Manual."),
-        ( "/forums", "medium", "Forums", "Navigation bar link to Mixxx Forums."),
-        ( "/wiki", "medium", "Wiki", "Navigation bar link to Mixxx Wiki."),
-        ( "http://mixxxblog.blogspot.com", "medium", "Blog", "Navigation bar link to Mixxx blog."),
-        ( "/press.html", "small", "Press", "Navigation bar link to Mixxx Press page"),
-        ( "/get-involved.html", "small", "Get Involved", "Navigation bar link to Mixxx Get Involved page." ),
-        ( "/contact.html", "small", "Contact", "Navigation bar link to Mixxx contact page.")
+        ("/manual/latest", "medium", "Manual", "Navigation bar link to Mixxx Manual."),
+        ("/forums", "medium", "Forums", "Navigation bar link to Mixxx Forums."),
+        ("/wiki", "medium", "Wiki", "Navigation bar link to Mixxx Wiki."),
+        ("http://mixxxblog.blogspot.com", "medium", "Blog", "Navigation bar link to Mixxx blog."),
+        ("/press.html", "small", "Press", "Navigation bar link to Mixxx Press page"),
+        ("/get-involved.html", "small", "Get Involved", "Navigation bar link to Mixxx Get Involved page." ),
+        ("/contact.html", "small", "Contact", "Navigation bar link to Mixxx contact page.")
     ]
 
     extra = {

--- a/plugins/page_context.py
+++ b/plugins/page_context.py
@@ -8,9 +8,23 @@ def preBuildPage(page, context, data):
     # This will run for each page that Cactus renders.
     # Any changes you make to context will be passed to the template renderer for this page.
 
+    menu = [
+        ("/download.html", "big", "Download", "Navigation bar link to Mixxx download page."),
+        ("/features.html", "big", "Features", "Navigation bar link to Mixxx features page."),
+        ("/support.html", "big", "Support & Community", "Navigation bar link to Mixxx support page."),
+        ( "/manual/latest", "medium", "Manual", "Navigation bar link to Mixxx Manual."),
+        ( "/forums", "medium", "Forums", "Navigation bar link to Mixxx Forums."),
+        ( "/wiki", "medium", "Wiki", "Navigation bar link to Mixxx Wiki."),
+        ( "http://mixxxblog.blogspot.com", "medium", "Blog", "Navigation bar link to Mixxx blog."),
+        ( "/press.html", "small", "Press", "Navigation bar link to Mixxx Press page"),
+        ( "/get-involved.html", "small", "Get Involved", "Navigation bar link to Mixxx Get Involved page." ),
+        ( "/contact.html", "small", "Contact", "Navigation bar link to Mixxx contact page.")
+    ]
+
     extra = {
-        "CURRENT_PAGE": page
+        "CURRENT_PAGE": page,
         # Add your own dynamic context elements here!
+        "NAV_MENU": menu
     }
 
     context.update(extra)

--- a/plugins/page_context.py
+++ b/plugins/page_context.py
@@ -9,16 +9,16 @@ def preBuildPage(page, context, data):
     # Any changes you make to context will be passed to the template renderer for this page.
 
     menu = [
-        ("/download.html", "big", "Download", "Navigation bar link to Mixxx download page."),
-        ("/features.html", "big", "Features", "Navigation bar link to Mixxx features page."),
-        ("/support.html", "big", "Support & Community", "Navigation bar link to Mixxx support page."),
+        ("/download", "big", "Download", "Navigation bar link to Mixxx download page."),
+        ("/features", "big", "Features", "Navigation bar link to Mixxx features page."),
+        ("/support", "big", "Support & Community", "Navigation bar link to Mixxx support page."),
         ("/manual/latest", "medium", "Manual", "Navigation bar link to Mixxx Manual."),
         ("/forums", "medium", "Forums", "Navigation bar link to Mixxx Forums."),
         ("/wiki", "medium", "Wiki", "Navigation bar link to Mixxx Wiki."),
         ("http://mixxxblog.blogspot.com", "medium", "Blog", "Navigation bar link to Mixxx blog."),
-        ("/press.html", "small", "Press", "Navigation bar link to Mixxx Press page"),
-        ("/get-involved.html", "small", "Get Involved", "Navigation bar link to Mixxx Get Involved page." ),
-        ("/contact.html", "small", "Contact", "Navigation bar link to Mixxx contact page.")
+        ("/press", "small", "Press", "Navigation bar link to Mixxx Press page"),
+        ("/get-involved", "small", "Get Involved", "Navigation bar link to Mixxx Get Involved page." ),
+        ("/contact", "small", "Contact", "Navigation bar link to Mixxx contact page.")
     ]
 
     extra = {

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -40,6 +40,10 @@ img
 {
     border: 0;
 }
+
+img.responsive
+{
+    max-width: 100%;
 }
 
 a:hover, #hamburger_menu a:hover {
@@ -55,6 +59,15 @@ p a
 
 h2 a {
   color: #ff9000; /* orange */
+}
+
+.center {
+    text-align: center;
+}
+
+img.center {
+    display: block;
+    margin: 0 auto;
 }
 
 #navbar
@@ -124,9 +137,9 @@ h2 a {
     text-align: center;
 }
 
-#splash img.background {
-    text-align: center;
-    margin:0 auto;
+#splash img {
+    height: auto;
+    width: 676px;
 }
 
 .gapfiller
@@ -346,15 +359,6 @@ h2 a {
 
     #hamburger_wrap {
         display: inherit!important;
-    }
-}
-
-/* less than the max size of the splash image, so we start to size it dynamically */
-@media only screen and (max-width: 676px)
-{
-    #splash img.background {
-        width: 100%;
-        height: 100%;
     }
 }
 

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -373,6 +373,12 @@ img.center
     {
         display: inherit!important;
     }
+
+    .footer_sitemap_column
+    {
+        width: auto;
+        margin-right: 20px;
+    }
 }
 
 

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -199,19 +199,15 @@ h2 a {
     margin-left: 60px;
 }
 
-.halfbox_left
+.halfbox_left, .halfbox_right
 {
     padding: 20px;
     float: left;
     width: 430px;
 }
 
-.halfbox_right
-{
-    padding: 20px;
+.halfbox_right {
     margin-left: 10px;
-    float: left;
-    width: 430px;
 }
 
 .darkborder

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -463,6 +463,8 @@ switch to hamburger menu
 #hamburger_wrap a
 {
   text-decoration: none;
+  -webkit-transition: color 0.3s ease;
+  -o-transition: color 0.3s ease;
   transition: color 0.3s ease;
 }
 
@@ -475,7 +477,9 @@ switch to hamburger menu
   
   z-index: 9;
   -webkit-user-select: none;
-  user-select: none;
+  -moz-user-select: none;
+   -ms-user-select: none;
+       user-select: none;
 }
 
 #hamburger_menu_toggle input
@@ -511,21 +515,46 @@ switch to hamburger menu
   
   z-index: 9;
   
-  transform-origin: 4px 0px;
+  -webkit-transform-origin: 4px 0px;
+  
+      -ms-transform-origin: 4px 0px;
+  
+          transform-origin: 4px 0px;
+  
+  -webkit-transition: background 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
+              opacity 0.55s ease,
+              -webkit-transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
+  
+  transition: background 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
+              opacity 0.55s ease,
+              -webkit-transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
+  
+  -o-transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
+              background 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
+              opacity 0.55s ease;
   
   transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
               background 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
               opacity 0.55s ease;
+  
+  transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
+              background 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
+              opacity 0.55s ease,
+              -webkit-transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
 }
 
 #hamburger_menu_toggle span:first-child
 {
-  transform-origin: 0% 0%;
+  -webkit-transform-origin: 0% 0%;
+      -ms-transform-origin: 0% 0%;
+          transform-origin: 0% 0%;
 }
 
 #hamburger_menu_toggle span:nth-last-child(2)
 {
-  transform-origin: 0% 100%;
+  -webkit-transform-origin: 0% 100%;
+      -ms-transform-origin: 0% 100%;
+          transform-origin: 0% 100%;
 }
 
 /* 
@@ -535,7 +564,9 @@ switch to hamburger menu
 #hamburger_menu_toggle input:checked ~ span
 {
   opacity: 1;
-  transform: rotate(45deg) translate(-2px, -1px);
+  -webkit-transform: rotate(45deg) translate(-2px, -1px);
+      -ms-transform: rotate(45deg) translate(-2px, -1px);
+          transform: rotate(45deg) translate(-2px, -1px);
   /*background: #232323;*/
 }
 
@@ -545,7 +576,9 @@ switch to hamburger menu
 #hamburger_menu_toggle input:checked ~ span:nth-last-child(3)
 {
   opacity: 0;
-  transform: rotate(0deg) scale(0.2, 0.2);
+  -webkit-transform: rotate(0deg) scale(0.2, 0.2);
+      -ms-transform: rotate(0deg) scale(0.2, 0.2);
+          transform: rotate(0deg) scale(0.2, 0.2);
 }
 
 /*
@@ -554,7 +587,9 @@ switch to hamburger menu
 #hamburger_menu_toggle input:checked ~ span:nth-last-child(2)
 {
   opacity: 1;
-  transform: rotate(-45deg) translate(0, -1px);
+  -webkit-transform: rotate(-45deg) translate(0, -1px);
+      -ms-transform: rotate(-45deg) translate(0, -1px);
+          transform: rotate(-45deg) translate(0, -1px);
 }
 
 /*
@@ -573,9 +608,17 @@ switch to hamburger menu
   list-style-type: none;
   -webkit-font-smoothing: antialiased;
   /* to stop flickering of text in safari */
-  transform-origin: 0% 0%;
-  transform: translate(100%, 0);
+  -webkit-transform-origin: 0% 0%;
+      -ms-transform-origin: 0% 0%;
+          transform-origin: 0% 0%;
+  -webkit-transform: translate(100%, 0);
+      -ms-transform: translate(100%, 0);
+          transform: translate(100%, 0);
+  -webkit-transition: -webkit-transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
+  transition: -webkit-transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
+  -o-transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
   transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
+  transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0), -webkit-transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
 }
 
 #hamburger_menu li
@@ -589,6 +632,8 @@ switch to hamburger menu
  */
 #hamburger_menu_toggle input:checked ~ ul
 {
-  transform: scale(1.0, 1.0);
+  -webkit-transform: scale(1.0, 1.0);
+      -ms-transform: scale(1.0, 1.0);
+          transform: scale(1.0, 1.0);
   opacity: 1;
 }

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -230,17 +230,13 @@ h2 a {
     z-index: 5;
     position: absolute;
     right: 10px;
-    float: right;
-    text-align: center;
-    padding: 0px;
-    margin: 0px;
+    top: 50px;
+    text-align: right;
 }
 #driveby_social li
 {
-    display: inline;
     list-style: none;
-    margin-left: 0;
-    padding-left: 0;
+    margin-bottom: 10px;
 }
 
 #footer_social

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -362,6 +362,11 @@ content in columns must be allowed to flow
         width: auto;
     }
 
+    .halfbox_right
+    {
+        margin-left: 0;
+    }
+
     .gapfiller p
     {
         margin-top: 0;

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -33,7 +33,7 @@ img
     border-style: none;
 }
 
-a:hover, #menu a:hover {
+a:hover, #hamburger_menu a:hover {
   /* text-decoration: underline; */
   /* color: #ffffff; */
   color: #ffB000; /* lighter orange */
@@ -312,7 +312,7 @@ h2 a {
         display: none;
     }
 
-    nav {
+    #hamburger_wrap {
         display: inherit!important;
     }
 }
@@ -333,20 +333,19 @@ body
   overflow-x: hidden; /* needed because hiding the menu on the right side is not perfect,  */
 }
 
-a
-{
-  text-decoration: none;
-  color: #232323;
-  
-  transition: color 0.3s ease;
-}
-
-nav {
+#hamburger_wrap {
     display: none;
     text-align: left;
     z-index: 8;
 }
-#menuToggle
+
+#hamburger_wrap a
+{
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+#hamburger_menu_toggle
 {
   display: block;
   position: absolute;
@@ -358,7 +357,7 @@ nav {
   user-select: none;
 }
 
-#menuToggle input
+#hamburger_menu_toggle input
 {
   display: block;
   width: 40px;
@@ -378,7 +377,7 @@ nav {
 /*
  * Just a quick hamburger
  */
-#menuToggle span
+#hamburger_menu_toggle span
 {
   display: block;
   width: 33px;
@@ -398,12 +397,12 @@ nav {
               opacity 0.55s ease;
 }
 
-#menuToggle span:first-child
+#hamburger_menu_toggle span:first-child
 {
   transform-origin: 0% 0%;
 }
 
-#menuToggle span:nth-last-child(2)
+#hamburger_menu_toggle span:nth-last-child(2)
 {
   transform-origin: 0% 100%;
 }
@@ -412,7 +411,7 @@ nav {
  * Transform all the slices of hamburger
  * into a crossmark.
  */
-#menuToggle input:checked ~ span
+#hamburger_menu_toggle input:checked ~ span
 {
   opacity: 1;
   transform: rotate(45deg) translate(-2px, -1px);
@@ -422,7 +421,7 @@ nav {
 /*
  * But let's hide the middle one.
  */
-#menuToggle input:checked ~ span:nth-last-child(3)
+#hamburger_menu_toggle input:checked ~ span:nth-last-child(3)
 {
   opacity: 0;
   transform: rotate(0deg) scale(0.2, 0.2);
@@ -431,7 +430,7 @@ nav {
 /*
  * Ohyeah and the last one should go the other direction
  */
-#menuToggle input:checked ~ span:nth-last-child(2)
+#hamburger_menu_toggle input:checked ~ span:nth-last-child(2)
 {
   opacity: 1;
   transform: rotate(-45deg) translate(0, -1px);
@@ -441,7 +440,7 @@ nav {
  * Make this absolute positioned
  * at the top left of the screen
  */
-#menu
+#hamburger_menu
 {
   position: absolute;
   width: 300px;
@@ -458,7 +457,7 @@ nav {
   transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
 }
 
-#menu li
+#hamburger_menu li
 {
   padding: 10px 0;
   font-size: 22px;
@@ -467,7 +466,7 @@ nav {
 /*
  * And let's fade it in from the left
  */
-#menuToggle input:checked ~ ul
+#hamburger_menu_toggle input:checked ~ ul
 {
   transform: scale(1.0, 1.0);
   opacity: 1;

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -33,7 +33,7 @@ img
     border-style: none;
 }
 
-a:hover {
+a:hover, nav a:hover {
   /* text-decoration: underline; */
   /* color: #ffffff; */
   color: #ffB000; /* lighter orange */
@@ -304,4 +304,188 @@ h2 a {
     {
         padding-right: 0;
     }
+}
+@media only screen and (max-width: 768px)
+{
+    #navbar_biglinks, #navbar_smalllinks
+    {
+        display: none;
+    }
+
+    nav {
+        display: inherit!important;
+    }
+}
+
+/*
+ * Made by Erik Terwan
+ * 24th of November 2015
+ * MIT license
+ *
+ *
+ * If you are thinking of using this in
+ * production code, beware of the browser
+ * prefixes.
+ */
+
+body
+{
+  margin: 0;
+  padding: 0;
+  
+  /* make it look decent enough */
+  background: #232323;
+  color: #cdcdcd;
+  font-family: "Avenir Next", "Avenir", sans-serif;
+  
+  overflow-x: hidden; /* needed because hiding the menu on the right side is not perfect,  */
+}
+
+a
+{
+  text-decoration: none;
+  color: #232323;
+  
+  transition: color 0.3s ease;
+}
+
+/*a:hover
+{
+  color: tomato;
+}*/
+
+nav {
+    display: none;
+    text-align: left;
+    z-index: 8;
+}
+#menuToggle
+{
+  display: block;
+  position: absolute;
+  top: 17px;
+  right: 17px;
+  
+  z-index: 9;
+  
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+#menuToggle input
+{
+  display: block;
+  width: 40px;
+  height: 32px;
+  position: absolute;
+  top: -7px;
+  left: -5px;
+  
+  cursor: pointer;
+  
+  opacity: 0; /* hide this */
+  z-index: 10; /* and place it over the hamburger */
+  
+  -webkit-touch-callout: none;
+}
+
+/*
+ * Just a quick hamburger
+ */
+#menuToggle span
+{
+  display: block;
+  width: 33px;
+  height: 4px;
+  margin-bottom: 5px;
+  position: relative;
+  
+  background: #cdcdcd;
+  border-radius: 3px;
+  
+  z-index: 9;
+  
+  transform-origin: 4px 0px;
+  
+  transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
+              background 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
+              opacity 0.55s ease;
+}
+
+#menuToggle span:first-child
+{
+  transform-origin: 0% 0%;
+}
+
+#menuToggle span:nth-last-child(2)
+{
+  transform-origin: 0% 100%;
+}
+
+/* 
+ * Transform all the slices of hamburger
+ * into a crossmark.
+ */
+#menuToggle input:checked ~ span
+{
+  opacity: 1;
+  transform: rotate(45deg) translate(-2px, -1px);
+  /*background: #232323;*/
+}
+
+/*
+ * But let's hide the middle one.
+ */
+#menuToggle input:checked ~ span:nth-last-child(3)
+{
+  opacity: 0;
+  transform: rotate(0deg) scale(0.2, 0.2);
+}
+
+/*
+ * Ohyeah and the last one should go the other direction
+ */
+#menuToggle input:checked ~ span:nth-last-child(2)
+{
+  opacity: 1;
+  transform: rotate(-45deg) translate(0, -1px);
+}
+
+/*
+ * Make this absolute positioned
+ * at the top left of the screen
+ */
+#menu
+{
+  position: absolute;
+  width: 300px;
+  margin: -100px 0 0 0;
+  padding: 50px;
+  padding-top: 125px;
+  right: -100px;
+  
+  background: #111111;
+  list-style-type: none;
+  -webkit-font-smoothing: antialiased;
+  /* to stop flickering of text in safari */
+  
+  transform-origin: 0% 0%;
+  transform: translate(100%, 0);
+  
+  transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
+}
+
+#menu li
+{
+  padding: 10px 0;
+  font-size: 22px;
+}
+
+/*
+ * And let's fade it in from the left
+ */
+#menuToggle input:checked ~ ul
+{
+  transform: scale(1.0, 1.0);
+  opacity: 1;
 }

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -211,9 +211,8 @@ p#navbar_tinylinks
 
 .achievement
 {
-    text-align: center;
-    display:inline-block;
-    padding-right: 30px;
+    display: inline-block;
+    margin-right: 20px;
 }
 
 .feature_icon

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -127,15 +127,6 @@ h2 a {
     margin:0 auto;
 }
 
-.download_button
-{
-    float: right;
-    text-align: center;
-    width: 246px;
-    font-size: 0.7em;
-    margin-right: -30px;
-}
-
 .gapfiller
 {
     font-size: 1.2em;
@@ -145,6 +136,25 @@ h2 a {
     color: #eeeeee;
     border: 1px #222222 solid;
     border-radius: 5px;
+    text-align:center;
+}
+
+.gapfiller p {
+    display:inline-block;
+}
+
+.gapfiller .download_button
+{
+    float:right;
+}
+
+.download_button img
+{
+    width: 246px;
+    height: 116px;
+    cursor: pointer;
+    border: 0;
+    margin: -29px;
 }
 
 .content
@@ -315,14 +325,24 @@ h2 a {
     }
 }
 
+/* less than the full width of the page */
 @media only screen and (max-width: 960px)
 {
     #wrapper, .halfbox_left, .halfbox_right
     {
         width: auto;
     }
+
+    .gapfiller p {
+        margin-top:0;
+    }
+    
+    .gapfiller .download_button {
+        float:inherit;
+    }
 }
 
+/* less than a standard tablet, we switch to hamburger menu */
 @media only screen and (max-width: 768px)
 {
     #navbar_biglinks, #navbar_smalllinks
@@ -335,6 +355,7 @@ h2 a {
     }
 }
 
+/* less than the max size of the splash image, so we start to size it dynamically */
 @media only screen and (max-width: 676px)
 {
     #splash img.background {
@@ -342,7 +363,6 @@ h2 a {
         height: 100%;
     }
 }
-
 
 
 /*

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -411,6 +411,10 @@ content in columns must be allowed to flow
     {
         margin-top: 0.4em;
     }
+
+    pre {
+        white-space: pre-line;
+    }
 }
 
 /*

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -1,4 +1,5 @@
-html, body {
+html, body
+{
     margin: 0;
     padding: 0;
     overflow-x: hidden;
@@ -21,13 +22,15 @@ body
     z-index: 0;
 }
 
-.oldwrappershadow {
+.oldwrappershadow
+{
     -moz-box-shadow: 0px 15px 15px #444444; /* FF3.5+ */
     -webkit-box-shadow: 0px 15px 15px #444444; /* Saf3.0+, Chrome */
     box-shadow: 0px 15px 15px #444444; /* Opera 10.5, IE9, Chrome 10+ */
 }
 
-a {
+a
+{
   /* color: #d0d0d0; very light grey */
   color: #ff9000; /* orange */
   /** color: #3030ff; blue **/
@@ -46,7 +49,8 @@ img.responsive
     max-width: 100%;
 }
 
-a:hover, #hamburger_menu a:hover {
+a:hover, #hamburger_menu a:hover
+{
   /* text-decoration: underline; */
   /* color: #ffffff; */
   color: #ffB000; /* lighter orange */
@@ -57,15 +61,18 @@ p a
   color: #ff9000; /* orange */
 }
 
-h2 a {
+h2 a
+{
   color: #ff9000; /* orange */
 }
 
-.center {
+.center
+{
     text-align: center;
 }
 
-img.center {
+img.center
+{
     display: block;
     margin: 0 auto;
 }
@@ -138,7 +145,8 @@ img.center {
     text-align: center;
 }
 
-#splash img {
+#splash img
+{
     height: auto;
     width: 676px;
 }
@@ -155,7 +163,8 @@ img.center {
     text-align:center;
 }
 
-.gapfiller p {
+.gapfiller p
+{
     display:inline-block;
 }
 
@@ -341,11 +350,13 @@ img.center {
         width: auto;
     }
 
-    .gapfiller p {
+    .gapfiller p
+    {
         margin-top:0;
     }
     
-    .gapfiller .download_button {
+    .gapfiller .download_button
+    {
         float:inherit;
     }
 }
@@ -358,7 +369,8 @@ img.center {
         display: none;
     }
 
-    #hamburger_wrap {
+    #hamburger_wrap
+    {
         display: inherit!important;
     }
 }
@@ -375,7 +387,8 @@ img.center {
  * prefixes.
  */
 
-#hamburger_wrap {
+#hamburger_wrap
+{
     display: none;
     text-align: left;
     z-index: 8;

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -133,6 +133,11 @@ img.center
     margin: 0px;
 }
 
+p#navbar_tinylinks
+{
+    font-size: 0.7em;
+}
+
 #splash
 {
     position: relative;
@@ -339,6 +344,11 @@ img.center
     {
         padding-right: 0;
     }
+
+    p#navbar_tinylinks
+    {
+        margin-left: 0.8em;
+    }
 }
 
 /*
@@ -402,7 +412,7 @@ content in columns must be allowed to flow
 screen too small to display menu
 switch to hamburger menu 
 */
-@media only screen and (max-width: 500px)
+@media only screen and (max-width: 530px)
 {
     #navbar_biglinks, #navbar_smalllinks
     {

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -38,7 +38,8 @@ a {
 
 img
 {
-    border-style: none;
+    border: 0;
+}
 }
 
 a:hover, #hamburger_menu a:hover {

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -33,7 +33,7 @@ img
     border-style: none;
 }
 
-a:hover, nav a:hover {
+a:hover, #menu a:hover {
   /* text-decoration: underline; */
   /* color: #ffffff; */
   color: #ffB000; /* lighter orange */
@@ -341,11 +341,6 @@ a
   transition: color 0.3s ease;
 }
 
-/*a:hover
-{
-  color: tomato;
-}*/
-
 nav {
     display: none;
     text-align: left;
@@ -359,7 +354,6 @@ nav {
   right: 17px;
   
   z-index: 9;
-  
   -webkit-user-select: none;
   user-select: none;
 }
@@ -452,18 +446,15 @@ nav {
   position: absolute;
   width: 300px;
   margin: -100px 0 0 0;
-  padding: 50px;
-  padding-top: 125px;
+  padding: 30px;
+  padding-top: 100px;
   right: -100px;
-  
   background: #111111;
   list-style-type: none;
   -webkit-font-smoothing: antialiased;
   /* to stop flickering of text in safari */
-  
   transform-origin: 0% 0%;
   transform: translate(100%, 0);
-  
   transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
 }
 

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -75,6 +75,7 @@ img.center {
     font-size: 1.4em;
     height: 55px;
     text-align: center;
+    overflow: hidden;
 }
 
 #navbar a

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -1,6 +1,7 @@
 html, body {
     margin: 0;
     padding: 0;
+    overflow-x: hidden;
 }
 
 body
@@ -372,15 +373,11 @@ h2 a {
  * prefixes.
  */
 
-body
-{
-  overflow-x: hidden; /* needed because hiding the menu on the right side is not perfect,  */
-}
-
 #hamburger_wrap {
     display: none;
     text-align: left;
     z-index: 8;
+    overflow-x:hidden;
 }
 
 #hamburger_wrap a

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -1,8 +1,14 @@
+html, body {
+    margin: 0;
+    padding: 0;
+}
+
 body
 {
     font-family: 'Muli', 'Corbel', 'Tahoma', 'Trebuchet MS', Verdana, arial, serif;
     background-color: #000000;
     color: #eeeeee;
+    margin: 0.5em;
 }
 
 #wrapper
@@ -13,6 +19,7 @@ body
     margin-right: auto;
     z-index: 0;
 }
+
 .oldwrappershadow {
     -moz-box-shadow: 0px 15px 15px #444444; /* FF3.5+ */
     -webkit-box-shadow: 0px 15px 15px #444444; /* Saf3.0+, Chrome */
@@ -117,6 +124,7 @@ h2 a {
 
 #splash img.background {
     text-align: center;
+    margin:0 auto;
 }
 
 .download_button
@@ -158,12 +166,13 @@ h2 a {
     color: #cccccc;
     border: 1px #222222 solid;
     border-radius: 5px;
+    text-align:center;
 }
 
 .achievement
 {
     text-align: center;
-    float: left;
+    display:inline-block;
     padding-right: 30px;
 }
 
@@ -305,6 +314,15 @@ h2 a {
         padding-right: 0;
     }
 }
+
+@media only screen and (max-width: 960px)
+{
+    #wrapper, .halfbox_left, .halfbox_right
+    {
+        width: auto;
+    }
+}
+
 @media only screen and (max-width: 768px)
 {
     #navbar_biglinks, #navbar_smalllinks
@@ -316,6 +334,16 @@ h2 a {
         display: inherit!important;
     }
 }
+
+@media only screen and (max-width: 676px)
+{
+    #splash img.background {
+        width: 100%;
+        height: 100%;
+    }
+}
+
+
 
 /*
  * Made by Erik Terwan

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -51,20 +51,29 @@ h2 a {
 #navbar
 {
     font-size: 1.4em;
+    height: 55px;
+    text-align: center;
 }
 
 #navbar a
 {
-  color: #d0d0d0;
+    color: #d0d0d0;
 }
 
+#nav_logo
+{
+    float: left;
+}
+
+#nav_logo img
+{
+    width: 190px;
+}
 
 #navbar_biglinks
 {
-    margin: 0 auto;
-    text-align: center;
-    padding-top: 10px;
-    height: 44px;
+    line-height: 55px;
+    display: inline-block;
 }
 
 #navbar_biglinks a
@@ -72,6 +81,7 @@ h2 a {
     padding-right: 25px;
     padding-left: 25px;
 }
+
 #navbar_smalllinks
 {
     float: right;
@@ -80,6 +90,7 @@ h2 a {
     text-align: right;
     height: 44px;
 }
+
 #navbar_smalllinks a
 {
     padding-left: 12px;
@@ -250,4 +261,47 @@ h2 a {
 {
     font-size: 0.7em;
     text-align: center;
+}
+
+
+/* squish menu items together for tablet style screens*/
+@media only screen and (max-width: 1100px)
+{
+    #navbar_biglinks 
+    {
+        display: inline-block;
+        line-height: inherit;
+    }
+
+    #navbar_biglinks a
+    {
+        padding-left: 0;
+        padding-right: 25px;
+    }
+
+    #navbar_biglinks a:last-child
+    {
+        padding-right: 0;
+    }
+
+    #navbar_smalllinks {
+        display: inline-block;
+        float: none;
+    }
+
+    #navbar_smalllinks p
+    {
+        display: inline;
+    }
+
+    #navbar_smalllinks a
+    {
+        padding-left: 0;
+        padding-right: 12px;
+    }
+
+    #navbar_smalllinks p > a:last-child
+    {
+        padding-right: 0;
+    }
 }

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -330,14 +330,6 @@ h2 a {
 
 body
 {
-  margin: 0;
-  padding: 0;
-  
-  /* make it look decent enough */
-  background: #232323;
-  color: #cdcdcd;
-  font-family: "Avenir Next", "Avenir", sans-serif;
-  
   overflow-x: hidden; /* needed because hiding the menu on the right side is not perfect,  */
 }
 

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -213,6 +213,7 @@ p#navbar_tinylinks
 {
     display: inline-block;
     margin-right: 20px;
+    vertical-align: top;
 }
 
 .feature_icon

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -299,8 +299,7 @@ img.center
     text-align: center;
 }
 
-
-/* squish menu items together for tablet style screens*/
+/* squish menu items together for tablet style screens */
 @media only screen and (max-width: 1100px)
 {
     #navbar_biglinks 
@@ -342,7 +341,10 @@ img.center
     }
 }
 
-/* less than the full width of the page */
+/*
+less than the full width of the page
+content in columns must be allowed to flow
+*/
 @media only screen and (max-width: 960px)
 {
     #wrapper, .halfbox_left, .halfbox_right
@@ -352,17 +354,55 @@ img.center
 
     .gapfiller p
     {
-        margin-top:0;
+        margin-top: 0;
     }
     
     .gapfiller .download_button
     {
-        float:inherit;
+        float: inherit;
     }
 }
 
-/* less than a standard tablet, we switch to hamburger menu */
+/* make menu font-size smaller as screen gets smaller */
 @media only screen and (max-width: 768px)
+{
+    #navbar
+    {
+        font-size: 1.2em;
+    }
+}
+
+@media only screen and (max-width: 650px)
+{
+    #navbar
+    {
+        font-size: 1em;
+    }
+
+    #navbar_biglinks
+    {
+        margin-top: 0.2em;
+    }
+}
+
+@media only screen and (max-width: 600px)
+{
+    #navbar
+    {
+        font-size: 0.8em;
+    }
+
+    #navbar_biglinks
+    {
+        margin-top: 0.4em;
+    }
+}
+
+/*
+screen too small to display menu
+switch to hamburger menu 
+*/
+@media only screen and (max-width: 500px)
 {
     #navbar_biglinks, #navbar_smalllinks
     {

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,7 +10,7 @@
     <meta name="google-site-verification" content="e7xeN8MhmdNedrrTVu7RRKXNl_8UBjg418brYV3XIPE" />
     <meta name="description" content="{% block meta_description %}{{ default_meta_description }}{% endblock %}">
     <meta name="keywords" content="{% block meta_keywords %}dj, dj software, free dj software, mixxx, dj mix, mp3 dj, mix mp3, download, crossfader, digital dj, beatmix, beatmixing, mp3, open source, mixing, mixer{% endblock %}"/>
-    <meta name="viewport" content="width=device-width">
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
 
     <meta property="og:type" content="website"/>
     <meta property="og:description" content="{{ default_meta_description }}"/>

--- a/templates/base.html
+++ b/templates/base.html
@@ -68,15 +68,6 @@
       !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
     </script>
 
-    <!-- G+ share button script -->
-    <script type="text/javascript">
-      (function() {
-        var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
-        po.src = 'https://apis.google.com/js/plusone.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
-      })();
-    </script>
-
     <script type="text/javascript">
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-3647499-1']);

--- a/templates/download_button.html
+++ b/templates/download_button.html
@@ -1,7 +1,5 @@
 <div class="download_button">
   <a href="/download/#stable">
-    <img src="{% static '/static/images/download.png' %}"
-         alt="Download Now for FREE!" border="0px"
-         style="vertical-align: middle; cursor:pointer; margin-top: -30px; margin-bottom: -30px;" />
+    <img src="{% static '/static/images/download.png' %}" alt="Download Now for FREE!" />
   </a>
 </div>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -4,9 +4,6 @@
   <div style="width: 440px; float: left;">
     <iframe src="http://www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.facebook.com%2Fpages%2FMIXXX-Digital-DJ%2F21723485212&amp;layout=standard&amp;show_faces=false&amp;width=440&amp;action=like&amp;colorscheme=dark&amp;height=24" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:440px; height:24px;" allowtransparency="true"></iframe>
   </div>
-  <div style="width: 440px; float: left;">
-    <g:plusone annotation="inline" href="http://www.mixxx.org"></g:plusone>
-  </div>
 
   <div style="clear: both;"></div>
 

--- a/templates/hamburger_menu.html
+++ b/templates/hamburger_menu.html
@@ -1,0 +1,34 @@
+{% load i18n %}
+<!--    Made by Erik Terwan    -->
+<!--   24th of November 2015   -->
+<!--        MIT License        -->
+<div id="hamburger_wrap">
+  <div id="hamburger_menu_toggle">
+    <!--
+    A fake / hidden checkbox is used as click reciever,
+    so you can use the :checked selector on it.
+    -->
+    <input type="checkbox" />
+    
+    <!--
+    Some spans to act as a hamburger.
+    
+    They are acting like a real hamburger,
+    not that McDonalds stuff.
+    -->
+    <span></span>
+    <span></span>
+    <span></span>
+    
+    <!--
+    Too bad the menu has to be inside of the button
+    but hey, it's pure CSS magic.
+    -->
+    <ul id="hamburger_menu">
+      <a href="/"><li>{% trans "Home" %}</li></a>
+    {% for href, size, title, cont in NAV_MENU %}
+      <a href="{{ href }}"><li>{% filter nbsp %}{% trans title context cont %}{% endfilter %}</li></a>
+    {% endfor %}
+    </ul>
+  </div>
+</div>

--- a/templates/hamburger_menu.html
+++ b/templates/hamburger_menu.html
@@ -1,29 +1,25 @@
 {% load i18n %}
+{% comment %}
 <!--    Made by Erik Terwan    -->
 <!--   24th of November 2015   -->
 <!--        MIT License        -->
+{% endcomment %}
 <div id="hamburger_wrap">
   <div id="hamburger_menu_toggle">
-    <!--
+    {% comment %}<!--
     A fake / hidden checkbox is used as click reciever,
     so you can use the :checked selector on it.
     -->
+    {% endcomment %}
     <input type="checkbox" />
-    
-    <!--
+    {% comment %}<!--
     Some spans to act as a hamburger.
-    
-    They are acting like a real hamburger,
-    not that McDonalds stuff.
     -->
+    {% endcomment %}
     <span></span>
     <span></span>
     <span></span>
-    
-    <!--
-    Too bad the menu has to be inside of the button
-    but hey, it's pure CSS magic.
-    -->
+
     <ul id="hamburger_menu">
       <a href="/"><li>{% trans "Home" %}</li></a>
     {% for href, size, title, cont in NAV_MENU %}

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -29,38 +29,6 @@
     {% endfor %}
     </p>
   </div>
+  {% include "hamburger_menu.html" %}
   <div style="clear: both;"></div>
-  <!--    Made by Erik Terwan    -->
-  <!--   24th of November 2015   -->
-  <!--        MIT License        -->
-  <div id="hamburger_wrap">
-    <div id="hamburger_menu_toggle">
-      <!--
-      A fake / hidden checkbox is used as click reciever,
-      so you can use the :checked selector on it.
-      -->
-      <input type="checkbox" />
-      
-      <!--
-      Some spans to act as a hamburger.
-      
-      They are acting like a real hamburger,
-      not that McDonalds stuff.
-      -->
-      <span></span>
-      <span></span>
-      <span></span>
-      
-      <!--
-      Too bad the menu has to be inside of the button
-      but hey, it's pure CSS magic.
-      -->
-      <ul id="hamburger_menu">
-        <a href="/"><li>{% trans "Home" %}</li></a>
-      {% for href, size, title, cont in NAV_MENU %}
-        <a href="{{ href }}"><li>{% filter nbsp %}{% trans title context cont %}{% endfilter %}</li></a>
-      {% endfor %}
-      </ul>
-    </div>
-  </div>
 </div>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -1,25 +1,32 @@
 {% load i18n %}
+
 <div id="navbar">
   <div id="nav_logo">
     <a href="/"><img src="{% static '/static/images/navbar_logo-2.0.png' %}" alt="Mixxx"></a>
   </div>
   <div id="navbar_biglinks">
-    <!-- using non-breaking spaces here! -->
-    <a class="menu_item" href="{% url '/download.html' %}">{% filter nbsp %}{% trans "Download" context "Navigation bar link to Mixxx download page." %}{% endfilter %}</a>
-    <a class="menu_item" href="{% url '/features.html' %}">{% filter nbsp %}{% trans "Features" context "Navigation bar link to Mixxx features page." %}{% endfilter %}</a>
-    <a class="menu_item" href="{% url '/support.html' %}">{% filter nbsp %}{% trans "Support &amp; Community" context "Navigation bar link to Mixxx support page." %}{% endfilter %}</a>
+  {% for href, size, title, cont in NAV_MENU %}
+    {# using non-breaking spaces here! #}
+    {% if size == 'big' %}
+    <a class="menu_item" href="{% url href %}">{% filter nbsp %}{% trans title context cont %}{% endfilter %}</a>
+    {% endif %}
+  {% endfor %}
   </div>
   <div id="navbar_smalllinks">
     <p>
-      <a class="menu_item" href="/manual/latest">{% trans "Manual" context "Navigation bar link to Mixxx Manual." %}</a>
-      <a class="menu_item" href="/forums">{% trans "Forums" context "Navigation bar link to Mixxx Forums." %}</a>
-      <a class="menu_item" href="/wiki">{% trans "Wiki" context "Navigation bar link to Mixxx Wiki." %}</a>
-      <a class="menu_item" href="http://mixxxblog.blogspot.com">{% trans "Blog" context "Navigation bar link to Mixxx blog." %}</a>
+    {% for href, size, title, cont in NAV_MENU %}
+      {% if size == 'medium' %}
+      <a class="menu_item" href="{% url href %}">{% filter nbsp %}{% trans title context cont %}{% endfilter %}</a>
+      {% endif %}
+    {% endfor %}
+
     </p>
     <p style="font-size: 0.7em">
-      <a class="menu_item" href="{% url '/press.html' %}">{% trans "Press" context "Navigation bar link to Mixxx Press page" %}</a>
-      <a class="menu_item" href="{% url '/get-involved.html' %}">{% filter nbsp %}{% trans "Get Involved" context "Navigation bar link to Mixxx Get Involved page." %}{% endfilter %}</a>
-      <a class="menu_item" href="{% url '/contact.html' %}">{% trans "Contact" context "Navigation bar link to Mixxx contact page." %}</a>
+    {% for href, size, title, cont in NAV_MENU %}
+      {% if size == 'small' %}
+      <a class="menu_item" href="{% url href %}">{% filter nbsp %}{% trans title context cont %}{% endfilter %}</a>
+      {% endif %}
+    {% endfor %}
     </p>
   </div>
   <div style="clear: both;"></div>
@@ -49,11 +56,10 @@
       but hey, it's pure CSS magic.
       -->
       <ul id="menu">
-        <a href="#"><li>Home</li></a>
-        <a href="#"><li>About</li></a>
-        <a href="#"><li>Info</li></a>
-        <a href="#"><li>Contact</li></a>
-        <a href="https://erikterwan.com/" target="_blank"><li>Show me more</li></a>
+        <a href="/"><li>{% trans "Home" %}</li></a>
+      {% for href, size, title, cont in NAV_MENU %}
+        <a href="{% url href %}"><li>{% filter nbsp %}{% trans title context cont %}{% endfilter %}</li></a>
+      {% endfor %}
       </ul>
     </div>
   </nav>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -8,7 +8,7 @@
   {% for href, size, title, cont in NAV_MENU %}
     {# using non-breaking spaces here! #}
     {% if size == 'big' %}
-    <a class="menu_item" href="{% url href %}">{% filter nbsp %}{% trans title context cont %}{% endfilter %}</a>
+    <a class="menu_item" href="{{ href }}">{% filter nbsp %}{% trans title context cont %}{% endfilter %}</a>
     {% endif %}
   {% endfor %}
   </div>
@@ -16,7 +16,7 @@
     <p>
     {% for href, size, title, cont in NAV_MENU %}
       {% if size == 'medium' %}
-      <a class="menu_item" href="{% url href %}">{% filter nbsp %}{% trans title context cont %}{% endfilter %}</a>
+      <a class="menu_item" href="{{ href }}">{% filter nbsp %}{% trans title context cont %}{% endfilter %}</a>
       {% endif %}
     {% endfor %}
 
@@ -24,7 +24,7 @@
     <p style="font-size: 0.7em">
     {% for href, size, title, cont in NAV_MENU %}
       {% if size == 'small' %}
-      <a class="menu_item" href="{% url href %}">{% filter nbsp %}{% trans title context cont %}{% endfilter %}</a>
+      <a class="menu_item" href="{{ href }}">{% filter nbsp %}{% trans title context cont %}{% endfilter %}</a>
       {% endif %}
     {% endfor %}
     </p>
@@ -58,7 +58,7 @@
       <ul id="menu">
         <a href="/"><li>{% trans "Home" %}</li></a>
       {% for href, size, title, cont in NAV_MENU %}
-        <a href="{% url href %}"><li>{% filter nbsp %}{% trans title context cont %}{% endfilter %}</li></a>
+        <a href="{{ href }}"><li>{% filter nbsp %}{% trans title context cont %}{% endfilter %}</li></a>
       {% endfor %}
       </ul>
     </div>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -23,4 +23,38 @@
     </p>
   </div>
   <div style="clear: both;"></div>
+  <!--    Made by Erik Terwan    -->
+  <!--   24th of November 2015   -->
+  <!--        MIT License        -->
+  <nav role='navigation'>
+    <div id="menuToggle">
+      <!--
+      A fake / hidden checkbox is used as click reciever,
+      so you can use the :checked selector on it.
+      -->
+      <input type="checkbox" />
+      
+      <!--
+      Some spans to act as a hamburger.
+      
+      They are acting like a real hamburger,
+      not that McDonalds stuff.
+      -->
+      <span></span>
+      <span></span>
+      <span></span>
+      
+      <!--
+      Too bad the menu has to be inside of the button
+      but hey, it's pure CSS magic.
+      -->
+      <ul id="menu">
+        <a href="#"><li>Home</li></a>
+        <a href="#"><li>About</li></a>
+        <a href="#"><li>Info</li></a>
+        <a href="#"><li>Contact</li></a>
+        <a href="https://erikterwan.com/" target="_blank"><li>Show me more</li></a>
+      </ul>
+    </div>
+  </nav>
 </div>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -33,8 +33,8 @@
   <!--    Made by Erik Terwan    -->
   <!--   24th of November 2015   -->
   <!--        MIT License        -->
-  <nav role='navigation'>
-    <div id="menuToggle">
+  <div id="hamburger_wrap">
+    <div id="hamburger_menu_toggle">
       <!--
       A fake / hidden checkbox is used as click reciever,
       so you can use the :checked selector on it.
@@ -55,12 +55,12 @@
       Too bad the menu has to be inside of the button
       but hey, it's pure CSS magic.
       -->
-      <ul id="menu">
+      <ul id="hamburger_menu">
         <a href="/"><li>{% trans "Home" %}</li></a>
       {% for href, size, title, cont in NAV_MENU %}
         <a href="{{ href }}"><li>{% filter nbsp %}{% trans title context cont %}{% endfilter %}</li></a>
       {% endfor %}
       </ul>
     </div>
-  </nav>
+  </div>
 </div>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -21,7 +21,7 @@
     {% endfor %}
 
     </p>
-    <p style="font-size: 0.7em">
+    <p id="navbar_tinylinks">
     {% for href, size, title, cont in NAV_MENU %}
       {% if size == 'small' %}
       <a class="menu_item" href="{{ href }}">{% filter nbsp %}{% trans title context cont %}{% endfilter %}</a>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -1,26 +1,26 @@
 {% load i18n %}
 <div id="navbar">
-  <div style="float: left;">
-    <a href="/"><img width="190px" src="{% static '/static/images/navbar_logo-2.0.png' %}" alt="Mixxx"></a>
-  </div>
-  <div id="navbar_smalllinks">
-    <p>
-      <a href="/manual/latest">{% trans "Manual" context "Navigation bar link to Mixxx Manual." %}</a>
-      <a href="/forums">{% trans "Forums" context "Navigation bar link to Mixxx Forums." %}</a>
-      <a href="/wiki">{% trans "Wiki" context "Navigation bar link to Mixxx Wiki." %}</a>
-      <a href="http://mixxxblog.blogspot.com">{% trans "Blog" context "Navigation bar link to Mixxx blog." %}</a>
-    </p>
-    <p style="font-size: 0.7em">
-      <a href="{% url '/press.html' %}">{% trans "Press" context "Navigation bar link to Mixxx Press page" %}</a>
-      <a href="{% url '/get-involved.html' %}">{% filter nbsp %}{% trans "Get Involved" context "Navigation bar link to Mixxx Get Involved page." %}{% endfilter %}</a>
-      <a href="{% url '/contact.html' %}">{% trans "Contact" context "Navigation bar link to Mixxx contact page." %}</a>
-    </p>
+  <div id="nav_logo">
+    <a href="/"><img src="{% static '/static/images/navbar_logo-2.0.png' %}" alt="Mixxx"></a>
   </div>
   <div id="navbar_biglinks">
     <!-- using non-breaking spaces here! -->
-    <a href="{% url '/download.html' %}">{% filter nbsp %}{% trans "Download" context "Navigation bar link to Mixxx download page." %}{% endfilter %}</a>
-    <a href="{% url '/features.html' %}">{% filter nbsp %}{% trans "Features" context "Navigation bar link to Mixxx features page." %}{% endfilter %}</a>
-    <a href="{% url '/support.html' %}">{% filter nbsp %}{% trans "Support &amp; Community" context "Navigation bar link to Mixxx support page." %}{% endfilter %}</a>
+    <a class="menu_item" href="{% url '/download.html' %}">{% filter nbsp %}{% trans "Download" context "Navigation bar link to Mixxx download page." %}{% endfilter %}</a>
+    <a class="menu_item" href="{% url '/features.html' %}">{% filter nbsp %}{% trans "Features" context "Navigation bar link to Mixxx features page." %}{% endfilter %}</a>
+    <a class="menu_item" href="{% url '/support.html' %}">{% filter nbsp %}{% trans "Support &amp; Community" context "Navigation bar link to Mixxx support page." %}{% endfilter %}</a>
+  </div>
+  <div id="navbar_smalllinks">
+    <p>
+      <a class="menu_item" href="/manual/latest">{% trans "Manual" context "Navigation bar link to Mixxx Manual." %}</a>
+      <a class="menu_item" href="/forums">{% trans "Forums" context "Navigation bar link to Mixxx Forums." %}</a>
+      <a class="menu_item" href="/wiki">{% trans "Wiki" context "Navigation bar link to Mixxx Wiki." %}</a>
+      <a class="menu_item" href="http://mixxxblog.blogspot.com">{% trans "Blog" context "Navigation bar link to Mixxx blog." %}</a>
+    </p>
+    <p style="font-size: 0.7em">
+      <a class="menu_item" href="{% url '/press.html' %}">{% trans "Press" context "Navigation bar link to Mixxx Press page" %}</a>
+      <a class="menu_item" href="{% url '/get-involved.html' %}">{% filter nbsp %}{% trans "Get Involved" context "Navigation bar link to Mixxx Get Involved page." %}{% endfilter %}</a>
+      <a class="menu_item" href="{% url '/contact.html' %}">{% trans "Contact" context "Navigation bar link to Mixxx contact page." %}</a>
+    </p>
   </div>
   <div style="clear: both;"></div>
 </div>


### PR DESCRIPTION
Was browsing the website on my phone the other morning and noticed that it wasn't optimized for mobile as noted in #11.

Further testing is needed before merging (am happy to do this), and there are a few areas where things could be improved. At time of writing, the footer could squeeze down a bit better, and some images on the features pages have fixed widths.

The biggest change is that the menu squishes together in two stages, eventually collapsing down into a CSS-only hamburger menu. To avoid repeating the menu items and also to avoid changing the existing structure too much, menu items are now defined on the page context found in `/plugins/page_context.py`. As far as I can tell, this is fairly standard using Cactus. The site should be basically identical when viewed on a wide screen desktop computer, but here it is before and after on smaller screens (emulated Firefox 62)

## 1000 x 1024:

### Before
![screen shot 2018-10-12 at 15 01 44](https://user-images.githubusercontent.com/1108600/46896088-479ca380-ce30-11e8-9ca2-3e11c47274ac.png)

### After
![screen shot 2018-10-12 at 15 01 48](https://user-images.githubusercontent.com/1108600/46896127-6c911680-ce30-11e8-81b4-2b308c571d97.png)

## 768 x 1024 (iPad)

### Before
![screen shot 2018-10-12 at 15 02 18](https://user-images.githubusercontent.com/1108600/46896146-89c5e500-ce30-11e8-95b7-74f281b9acd1.png)

### After
![screen shot 2018-10-12 at 15 02 23](https://user-images.githubusercontent.com/1108600/46896147-8c283f00-ce30-11e8-938b-4a419cfc0dde.png)

### After, with open hamburger menu
![screen shot 2018-10-12 at 15 02 29](https://user-images.githubusercontent.com/1108600/46896150-8df20280-ce30-11e8-801d-83c4ac5d1770.png)

## 375 x 667 (iPhone 6/7/8)

### Before
![screen shot 2018-10-12 at 15 02 39](https://user-images.githubusercontent.com/1108600/46896165-a8c47700-ce30-11e8-9aca-4a03dba842fb.png)

### After
![screen shot 2018-10-12 at 15 02 46](https://user-images.githubusercontent.com/1108600/46896166-a9f5a400-ce30-11e8-990b-8a87d270e15b.png)

### After, with open hamburger menu
![screen shot 2018-10-12 at 15 02 51](https://user-images.githubusercontent.com/1108600/46896170-ab26d100-ce30-11e8-89e5-ed4b30c047a0.png)

A very elegant, pure CSS, MIT licensed hamburger menu implementation was adopted from https://codepen.io/erikterwan/pen/grOZxx Vendor prefixes for some properties are required. We can also make it less fancy if desired. A JS implementation is also trivially possible, but I think sticking with CSS only is ideal.