### PR TITLE
update Download page for 2.2.0 release

### DIFF
--- a/pages/download.html
+++ b/pages/download.html
@@ -1,45 +1,58 @@
-show_unstable: yes
+show_unstable: no
 show_previous: yes
-unstable_version: Mixxx 2.2.0 Release Candidate
-unstable_win32: http://downloads.mixxx.org/builds/2.2/release/mixxx-2.2.0-rc-2.2-release-x86-latest.exe
-unstable_win64: http://downloads.mixxx.org/builds/2.2/release/mixxx-2.2.0-rc-2.2-release-x64-latest.exe
-unstable_osxintel: http://downloads.mixxx.org/builds/2.2/release/mixxx-2.2.0-rc-2.2-release-macintel64-latest.dmg
-unstable_ubuntu32: http://downloads.mixxx.org/builds/2.2/release/mixxx-2.2.0-rc-2.2-release-bionic-i386-latest.deb
-unstable_ubuntu64: http://downloads.mixxx.org/builds/2.2/release/mixxx-2.2.0-rc-2.2-release-bionic-amd64-latest.deb
-unstable_linuxsrc: FIXME
-unstable_linuxsrc_analytics_conversion: /downloads/2.1.0-rc1-linuxsrc
-unstable_win32_analytics_conversion: /downloads/2.1.0-rc1-win32
-unstable_win64_analytics_conversion: /downloads/2.1.0-rc1-win64
-unstable_osxintel_analytics_conversion: /downloads/2.1.0-rc1-osxintel
-unstable_ubuntu32_analytics_conversion: /downloads/2.1.0-rc1-ubuntu32
-unstable_ubuntu64_analytics_conversion: /downloads/2.1.0-rc1-ubuntu64
-unstable_ubuntu_ppa_analytics_conversion: /downloads/2.1.0-rc1-ubuntu-ppa
-stable_version: Mixxx 2.1.5
-stable_win32: https://downloads.mixxx.org/mixxx-2.1.5/mixxx-2.1.5-win32.exe
-stable_win64: https://downloads.mixxx.org/mixxx-2.1.5/mixxx-2.1.5-win64.exe
-stable_osxintel: https://downloads.mixxx.org/mixxx-2.1.5/mixxx-2.1.5-osxintel.dmg
-stable_ubuntu32: https://downloads.mixxx.org/mixxx-2.1.5/mixxx-2.1.5-bionic-i386.deb
-stable_ubuntu64: https://downloads.mixxx.org/mixxx-2.1.5/mixxx-2.1.5-bionic-amd64.deb
-stable_linuxsrc: https://github.com/mixxxdj/mixxx/archive/release-2.1.5.tar.gz
-stable_win32_analytics_conversion: /downloads/2.1.5-win32
-stable_win64_analytics_conversion: /downloads/2.1.5-win64
-stable_osxintel_analytics_conversion: /downloads/2.1.5-osxintel
-stable_ubuntu32_analytics_conversion: /downloads/2.1.5-ubuntu-bionic32
-stable_ubuntu64_analytics_conversion: /downloads/2.1.5-ubuntu-bionic64
+
+unstable_version: Mixxx 2.3.0 Beta
+next_stable_version: 2.3.0
+unstable_release_announcement: FIXME
+unstable_win_min_version: 7
+unstable_macos_min_version: 10.11
+unstable_ubuntu_min_version: 18.04 (Bionic)
+unstable_git_branch: 2.3
+unstable_win32: http://downloads.mixxx.org/builds/2.3/release/mixxx-2.3.0-rc-2.3-release-x86-latest.exe
+unstable_win64: http://downloads.mixxx.org/builds/2.3/release/mixxx-2.3.0-rc-2.3-release-x64-latest.exe
+unstable_osxintel: http://downloads.mixxx.org/builds/2.3/release/mixxx-2.3.0-rc-2.3-release-macintel64-latest.dmg
+unstable_ubuntu32: http://downloads.mixxx.org/builds/2.3/release/mixxx-2.3.0-rc-2.3-release-bionic-i386-latest.deb
+unstable_ubuntu64: http://downloads.mixxx.org/builds/2.3/release/mixxx-2.3.0-rc-2.3-release-bionic-amd64-latest.deb
+unstable_win32_analytics_conversion: /downloads/2.3.0-beta-win32
+unstable_win64_analytics_conversion: /downloads/2.3.0-beta-win64
+unstable_osxintel_analytics_conversion: /downloads/2.3.0-beta-osxintel
+unstable_ubuntu32_analytics_conversion: /downloads/2.3.0-beta-ubuntu32
+unstable_ubuntu64_analytics_conversion: /downloads/2.3.0-beta-ubuntu64
+unstable_ubuntu_ppa_analytics_conversion: /downloads/2.3.0-beta-ubuntu-ppa
+
+stable_version: Mixxx 2.2.0
+stable_release_announcement: https://mixxx.org/forums/viewtopic.php?f=1&t=12368
+stable_win_min_version: 7
+stable_macos_min_version: 10.11
+stable_ubuntu_min_version: 16.04 (Xenial)
+stable_git_branch: 2.2
+stable_win32: https://downloads.mixxx.org/mixxx-2.2.0/mixxx-2.2.0-win32.exe
+stable_win64: https://downloads.mixxx.org/mixxx-2.2.0/mixxx-2.2.0-win64.exe
+stable_osxintel: https://downloads.mixxx.org/mixxx-2.2.0/mixxx-2.2.0-osxintel.dmg
+stable_ubuntu32: https://downloads.mixxx.org/mixxx-2.2.0/mixxx-2.2.0-bionic-i386.deb
+stable_ubuntu64: https://downloads.mixxx.org/mixxx-2.2.0/mixxx-2.2.0-bionic-amd64.deb
+stable_linuxsrc: https://github.com/mixxxdj/mixxx/archive/release-2.2.0.tar.gz
+stable_win32_analytics_conversion: /downloads/2.2.0-win32
+stable_win64_analytics_conversion: /downloads/2.2.0-win64
+stable_osxintel_analytics_conversion: /downloads/2.2.0-osxintel
+stable_ubuntu32_analytics_conversion: /downloads/2.2.0-ubuntu-bionic32
+stable_ubuntu64_analytics_conversion: /downloads/2.2.0-ubuntu-bionic64
 stable_ubuntu_ppa_analytics_conversion: NOT YET EXTRACTED, FIX ME BELOW
-stable_linuxsrc_analytics_conversion: /downloads/2.1.5-linuxsrc
-previous_version: Mixxx 2.0.0
-previous_win32: https://downloads.mixxx.org/mixxx-2.0.0/mixxx-2.0.0-win32.exe
-previous_win64: https://downloads.mixxx.org/mixxx-2.0.0/mixxx-2.0.0-win64.exe
-previous_osxintel: https://downloads.mixxx.org/mixxx-2.0.0/mixxx-2.0.0-osxintel.dmg
-previous_ubuntu32: https://downloads.mixxx.org/mixxx-2.0.0/mixxx-2.0.0-trusty-i386.deb
-previous_ubuntu64: https://downloads.mixxx.org/mixxx-2.0.0/mixxx-2.0.0-trusty-amd64.deb
-previous_linuxsrc: https://downloads.mixxx.org/mixxx-2.0.0/mixxx-2.0.0-src.tar.gz
-previous_win32_analytics_conversion: /downloads/2.0win32
-previous_win64_analytics_conversion: /downloads/2.0win64
-previous_osxintel_analytics_conversion: /downloads/2.0osxintel
-previous_osxppc_analytics_conversion: /downloads/2.0osxppc
-previous_linuxsrc_analytics_conversion: /downloads/2.0linuxsrc
+stable_linuxsrc_analytics_conversion: /downloads/2.2.0-linuxsrc
+
+previous_version: Mixxx 2.1.5
+previous_win32: https://downloads.mixxx.org/mixxx-2.1.5/mixxx-2.1.5-win32.exe
+previous_win64: https://downloads.mixxx.org/mixxx-2.1.5/mixxx-2.1.5-win64.exe
+previous_win_min_version: XP
+previous_osxintel: https://downloads.mixxx.org/mixxx-2.1.5/mixxx-2.1.5-osxintel.dmg
+previous_macos_min_version: 10.8
+previous_ubuntu32: https://downloads.mixxx.org/mixxx-2.1.5/mixxx-2.1.5-bionic-i386.deb
+previous_ubuntu64: https://downloads.mixxx.org/mixxx-2.1.5/mixxx-2.1.5-bionic-amd64.deb
+previous_linuxsrc: https://downloads.mixxx.org/mixxx-2.1.5/mixxx-2.1.5-src.tar.gz
+previous_win32_analytics_conversion: /downloads/2.1.5-win32
+previous_win64_analytics_conversion: /downloads/2.1.5-win64
+previous_osxintel_analytics_conversion: /downloads/2.1.5-osxintel
+previous_linuxsrc_analytics_conversion: /downloads/2.1.5-linuxsrc
 previous_ubuntu_ppa_analytics_conversion: NOT YET EXTRACTED, FIX ME BELOW
 {% extends "base.html" %}
 
@@ -85,12 +98,15 @@ $(document).ready(function() {
   <div style="padding: 20px;">
     <p><h2>For live use, we recommend <a href="#stable">{{ stable_version }} Stable</a> below.</h2></p>
     <p>
-      {% blocktrans with mixxx_22_rc_forum_link="https://mixxx.org/forums/viewtopic.php?f=1&amp;t=12152" %}The Mixxx team has been working hard on Mixxx 2.2. Check out the <a href="{{ mixxx_22_rc_forum_link }}">release announcement</a> for a list of the new features.{% endblocktrans %}
+      {% blocktrans %}The Mixxx team has been working hard on the next version of Mixxx. Check out the <a href="{{ unstable_release_announcement }}">release announcement</a> for a list of the new features.{% endblocktrans %}
     </p>
 
     <p>
-      <b>{% trans "Important:" %}</b> {% blocktrans with stable_link="#stable" %}While Mixxx 2.2 has been stable in testing it is not yet recommended for live use unless you are willing to risk a crash. Looking for the stable release? <a href="{{ stable_link }}">Scroll on down.{% endblocktrans %}</a>
+      <b>{% trans "Important:" %}</b> {% blocktrans with stable_link="#stable" %}While {{ unstable_version }} has been stable in testing it is not yet recommended for live use unless you are willing to risk a crash. Looking for the stable release? <a href="{{ stable_link }}">Scroll on down.{% endblocktrans %}</a>
     </p>
+
+    <p>{% trans "Mixxx is available for Windows, macOS, and Linux. We happily provide Mixxx for free and donations are appreciated!" %}</p>
+    {% include "donate_paypal.html" %}
   </div>
 
   <div style="clear: both;"></div>
@@ -100,18 +116,16 @@ $(document).ready(function() {
     <p>
       <a href="{{ unstable_win32 }}"
          onClick="javascript:trackDownload('{{ unstable_win32_analytics_conversion }}');">
-        {% blocktrans %}Download {{ unstable_version }} for 32-bit Windows{% endblocktrans %}</a>
+        {% blocktrans %}Download {{ unstable_version }} for 32-bit Windows {{ unstable_win_min_version }} or later {% endblocktrans %}</a>
     </p>
 
     <p>
       <a href="{{ unstable_win64 }}"
          onClick="javascript:trackDownload('{{ unstable_win64_analytics_conversion }}');">
-        {% blocktrans %}Download {{ unstable_version }} for 64-bit Windows{% endblocktrans %}</a>
+        {% blocktrans %}Download {{ unstable_version }} for 64-bit Windows {{ unstable_win_min_version }} or later{% endblocktrans %}</a>
     </p>
 
-    <p>New versions will be made available every time the code is changed, so check back periodically for updates until Mixxx 2.2 is released.</p>
-
-    <p><small>{% blocktrans %}Supported on Windows 7 and newer.{% endblocktrans %}</small></p>
+    <p>New versions will be made available every time the code is changed, so check back periodically for updates until Mixxx {{ next_stable_version }} is released.</p>
   </div>
 
   <div class="halfbox_right darkborder macbox">
@@ -120,10 +134,10 @@ $(document).ready(function() {
     <p>
       <a href="{{ unstable_osxintel }}"
          onClick="javascript:trackDownload('{{ unstable_osxintel_analytics_conversion }}');">
-        {% blocktrans %}Download {{ unstable_version }} for macOS 10.11+ (Intel){% endblocktrans %}</a>
+        {% blocktrans %}Download {{ unstable_version }} for macOS {{ unstable_macos_min_version }} or later (Intel){% endblocktrans %}</a>
     </p>
 
-    <p>{% blocktrans %}New versions will be made available every time the code is changed, so check back periodically for updates until Mixxx 2.2 is released.{% endblocktrans %}</p>
+    <p>{% blocktrans %}New versions will be made available every time the code is changed, so check back periodically for updates until Mixxx {{ next_stable_version }} is released.{% endblocktrans %}</p>
 
   </div>
 
@@ -135,25 +149,25 @@ $(document).ready(function() {
     <p>{% trans "Open a terminal, and enter:" %}</p>
     <pre>
       sudo add-apt-repository ppa:mixxx/mixxxbetas
-      sudo apt-get update
-      sudo apt-get install mixxx
+      sudo apt update
+      sudo apt install mixxx
     </pre>
 
     <p>
-      {% with "<a href='https://launchpad.net/~mixxx/+archive/mixxxbetas' onclick=\"javascript:trackDownload('/downloads/2.1.0-ubuntu-ppa');\">"|add:mixxx_ppa|add:"</a>" as ppa_link %}
+      {% with "<a href='https://launchpad.net/~mixxx/+archive/mixxxbetas' onclick=\"javascript:trackDownload('/downloads/2.3.0-ubuntu-ppa');\">"|add:mixxx_ppa|add:"</a>" as ppa_link %}
       {% blocktrans %}This will install the latest version of Mixxx from the {{ ppa_link }} on Launchpad.{% endblocktrans %}
       {% endwith %}
     </p>
 
-    <p>{% blocktrans %}New installers will be made available every time the code is changed. If you are using the PPA, these will be installed automatically with apt-get. Otherwise, you can download individual packages to install and check back periodically for updates until Mixxx 2.2 is released:{% endblocktrans %}</p>
+    <p>{% blocktrans %}New packages will be made available every time the code is changed. If you are using the PPA, these will be installed automatically with apt. Otherwise, you can download individual packages to install and check back periodically for updates until Mixxx {{ next_stable_version }} is released:{% endblocktrans %}</p>
 
     <p><a href="{{ unstable_ubuntu32 }}"
           onclick="javascript:trackDownload('{{ unstable_ubuntu32_analytics_conversion }}');">
-        {% blocktrans %}{{ unstable_version }} for 32-bit Ubuntu Bionic{% endblocktrans %}</a></p>
+        {% blocktrans %}{{ unstable_version }} for 32-bit Ubuntu {{ unstable_ubuntu_min_version }} or later{% endblocktrans %}</a></p>
 
     <p><a href="{{ unstable_ubuntu64 }}"
           onclick="javascript:trackDownload('{{ unstable_ubuntu64_analytics_conversion }}');">
-        {% blocktrans %}{{ unstable_version }} for 64-bit Ubuntu Bionic{% endblocktrans %}</a></p>
+        {% blocktrans %}{{ unstable_version }} for 64-bit Ubuntu {{ unstable_ubuntu_min_version }} or later{% endblocktrans %}</a></p>
   </div>
 
   <div class="halfbox_right darkborder fedorabox">
@@ -166,7 +180,7 @@ $(document).ready(function() {
       {% endblocktrans %}</p>
 
     <p>{% blocktrans %}
-      Please refer to their <a href="https://rpmfusion.org/Configuration">instructions</a>
+      Please refer to <a href="https://rpmfusion.org/Configuration">RPM Fusion's instructions</a>
       on how to enable the repositories on your system. Mixxx only requires enabling the
       free repository; the nonfree repository is not necessary for Mixxx.
       {% endblocktrans %}
@@ -180,8 +194,8 @@ $(document).ready(function() {
     </p>
 
     <p>{% blocktrans %}
-      Only the most recent version of Mixxx is provided and continuously updated
-      during the maintenance period.
+      The beta package will be continuously updated until Mixxx {{ next_stable_version }}
+      is released.
       {% endblocktrans %}
     </p>
   </div>
@@ -193,8 +207,8 @@ $(document).ready(function() {
 
     <p>
       {% blocktrans with mixxx_license_file="https://github.com/mixxxdj/mixxx/blob/2.2/LICENSE" %}The Mixxx source code is published under the GNU General Public License (GPL) v2 or later. Please check the <a href="{{ mixxx_license_file }}">LICENSE file</a> in our source tree for complete licensing information. {% endblocktrans %}
-      {% blocktrans with mixxx_github_link="https://github.com/mixxxdj/mixxx" %}Download the latest code from Mixxx's 2.2 branch on <a href="{{ mixxx_github_link }}">GitHub</a> by opening a terminal and running:{% endblocktrans %}
-      <pre>        git clone -b 2.2 https://github.com/mixxxdj/mixxx.git</pre>
+      {% blocktrans with mixxx_github_link="https://github.com/mixxxdj/mixxx" %}Download the latest code from Mixxx's {{ unstable_git_branch }} branch on <a href="{{ mixxx_github_link }}">GitHub</a> by opening a terminal and running:{% endblocktrans %}
+      <pre>        git clone -b {{ unstable_git_branch }} https://github.com/mixxxdj/mixxx.git</pre>
     </p>
 
     <p>
@@ -205,9 +219,7 @@ $(document).ready(function() {
 
   <a name="stable"></a>
   <h1>{% blocktrans %}Download Now ({{ stable_version }} Stable){% endblocktrans %}</h1>
-  <!-- TODO: Eventually remove when stable_version is no longer 2.0.  Leaving the text literal
-  so the bad link is more easily caught. -->
-  <p>{% blocktrans with release_announcement_link="https://mixxx.org/forums/viewtopic.php?f=1&amp;t=11761" %}Check out the <a href="{{ release_announcement_link }}">release announcement</a> for a list of new features.{% endblocktrans %}</p>
+  <p>{% blocktrans %}Check out the <a href="{{ stable_release_announcement }}">release announcement</a> for a list of new features.{% endblocktrans %}</p>
   <p>{% blocktrans with previous_link="#previous" %}(Although {{ stable_version }} contains many important updates and bugfixes, it's possible some users may experience issues. If you do, you can still get our previous stable version, <a href="{{ previous_link }}">{{ previous_version }}</a>.){% endblocktrans %}</p>
   <p>{% trans "Mixxx is available for Windows, macOS, and Linux. We happily provide Mixxx for free and donations are appreciated!" %}</p>
   {% include "donate_paypal.html" %}
@@ -219,17 +231,14 @@ $(document).ready(function() {
     <p>
       <a href="{{ stable_win32 }}"
          onClick="javascript:trackDownload('{{ stable_win32_analytics_conversion }}');">
-        {% blocktrans %}Download {{ stable_version }} for 32-bit Windows{% endblocktrans %}</a>
+        {% blocktrans %}Download {{ stable_version }} for 32-bit Windows {{ stable_win_min_version }} or later{% endblocktrans %}</a>
     </p>
 
     <p>
       <a href="{{ stable_win64 }}"
          onClick="javascript:trackDownload('{{ stable_win64_analytics_conversion }}');">
-        {% blocktrans %}Download {{ stable_version }} for 64-bit Windows{% endblocktrans %}</a>
+        {% blocktrans %}Download {{ stable_version }} for 64-bit Windows {{ stable_win_min_version }} or later{% endblocktrans %}</a>
     </p>
-
-    <br>
-    <p><small>{% trans "Supported on Windows XP and newer." %} {% blocktrans with platform_update_link="https://support.microsoft.com/en-us/kb/2117917" %}AAC playback requires at least Windows 7 or Windows Vista with a <a href="{{ platform_update_link }}">platform update</a>.{% endblocktrans %}</small></p>
   </div>
 
   <div class="halfbox_right darkborder macbox">
@@ -237,7 +246,7 @@ $(document).ready(function() {
     <p>
       <a href="{{ stable_osxintel }}"
          onClick="javascript:trackDownload('{{ stable_osxintel_analytics_conversion }}');">
-        {% blocktrans %}Download {{ stable_version }} for macOS 10.8+ (Intel){% endblocktrans %}</a>
+        {% blocktrans %}Download {{ stable_version }} for macOS {{ stable_macos_min_version }} or later (Intel){% endblocktrans %}</a>
     </p>
 
     <!-- NOTE(rryan): Temporarily hidden while we get back on the Mac App Store -->
@@ -255,17 +264,15 @@ $(document).ready(function() {
 
   <div class="halfbox_left darkborder ubuntubox">
     <h2><img src="{% static '/static/images/download_ubuntu.png' %}" class="feature_icon">{{ ubuntu }}</h2>
-    {% trans "Ubuntu 14.04 (Trusty)" as stable_ubuntu_min_supported_version %}
-    {% trans "Ubuntu 18.04 (Bionic)" as stable_ubuntu_max_supported_version %}
-    <p>{% blocktrans %}Download {{ stable_version }} for {{ stable_ubuntu_min_supported_version }} through {{ stable_ubuntu_max_supported_version}}:{% endblocktrans %}</p>
+    <p>{% blocktrans %}Download {{ stable_version }} for {{ stable_ubuntu_min_version }} or later:{% endblocktrans %}</p>
     <p>{% trans "Open a terminal, and enter:" %}</p>
     <pre>
       sudo add-apt-repository ppa:mixxx/mixxx
-      sudo apt-get update
-      sudo apt-get install mixxx
+      sudo apt update
+      sudo apt install mixxx
     </pre>
     <p>
-      {% with "<a href='https://launchpad.net/~mixxx/+archive/mixxx' onclick=\"javascript:trackDownload('/downloads/2.1.0-ubuntu-ppa');\">"|add:mixxx_ppa|add:"</a>" as ppa_link %}
+      {% with "<a href='https://launchpad.net/~mixxx/+archive/mixxx' onclick=\"javascript:trackDownload('/downloads/2.2.0-ubuntu-ppa');\">"|add:mixxx_ppa|add:"</a>" as ppa_link %}
       {% blocktrans %}This will install the latest version of Mixxx from the {{ ppa_link }} on Launchpad.{% endblocktrans %}
       {% endwith %}
     </p>
@@ -278,7 +285,7 @@ $(document).ready(function() {
         {% blocktrans %}{{ stable_version }} for 64-bit Ubuntu Bionic{% endblocktrans %}</a></p>
 
     <div style="width: 66%; margin: 0 auto;">
-      <small><b>{% trans "Ubuntu Repositories" %}:</b><br/>{% blocktrans %}Ubuntu also provides a version of Mixxx which can be installed directly from the Ubuntu Software Centre. This version is usually woefully out of date; therefore using the PPA is preferable.{% endblocktrans %}</small>
+      <small><b>{% trans "Ubuntu Repositories" %}:</b><br/>{% blocktrans %}Ubuntu also provides a version of Mixxx which can be installed directly from the Ubuntu Software Centre. This version is usually woefully out of date; therefore using the PPA is advised.{% endblocktrans %}</small>
     </div>
   </div>
 
@@ -292,7 +299,7 @@ $(document).ready(function() {
       {% endblocktrans %}</p>
 
     <p>{% blocktrans %}
-      Please refer to their <a href="https://rpmfusion.org/Configuration">instructions</a>
+      Please refer to <a href="https://rpmfusion.org/Configuration">RPM Fusion's instructions</a>
       on how to enable the repositories on your system. Mixxx only requires enabling the
       free repository; the nonfree repository is not necessary for Mixxx.
       {% endblocktrans %}
@@ -302,12 +309,6 @@ $(document).ready(function() {
       RPM Fusion builds are maintained by the Mixxx development team.
       We support the next, the current, and selected previous
       Fedora release(s) if possible.
-      {% endblocktrans %}
-    </p>
-
-    <p>{% blocktrans %}
-      Only the most recent version of Mixxx is provided and continuously updated
-      during the maintenance period.
       {% endblocktrans %}
     </p>
   </div>
@@ -325,8 +326,8 @@ $(document).ready(function() {
 
     <p>
       {% trans "The Mixxx source code is made available under the GPL v2 or later. Please check the LICENSE file in our source tree for complete licensing information." %}
-      {% blocktrans with mixxx_github_link="https://github.com/mixxxdj/mixxx" %}The latest code from Mixxx's development branch is hosted on <a href="{{ mixxx_github_link }}">GitHub</a>:{% endblocktrans %}
-      <pre>        git clone -b 2.1 https://github.com/mixxxdj/mixxx.git</pre>
+      {% blocktrans with mixxx_github_link="https://github.com/mixxxdj/mixxx" %}The latest code from Mixxx's {{ stable_git_branch }} branch is hosted on <a href="{{ mixxx_github_link }}">GitHub</a>:{% endblocktrans %}
+      <pre>        git clone -b {{ stable_git_branch }} https://github.com/mixxxdj/mixxx.git</pre>
     </p>
 
     <p>
@@ -346,13 +347,13 @@ $(document).ready(function() {
     <p>
       <a href="{{ previous_win32 }}"
          onClick="javascript:trackDownload('{{ previous_win32_analytics_conversion }}');">
-        {% blocktrans %}Download {{ previous_version }} for 32-bit Windows{% endblocktrans %}</a>
+        {% blocktrans %}Download {{ previous_version }} for 32-bit Windows {{ previous_win_min_version }} or later {% endblocktrans %}</a>
     </p>
 
     <p>
       <a href="{{ previous_win64 }}"
          onClick="javascript:trackDownload('{{ previous_win64_analytics_conversion }}');">
-        {% blocktrans %}Download {{ previous_version }} for 64-bit Windows{% endblocktrans %}</a>
+        {% blocktrans %}Download {{ previous_version }} for 64-bit Windows {{ previous_win_min_version }} or later {% endblocktrans %}</a>
     </p>
 
     <br>
@@ -364,12 +365,7 @@ $(document).ready(function() {
     <p>
       <a href="{{ previous_osxintel }}"
          onClick="javascript:trackDownload('{{ previous_osxintel_analytics_conversion }}');">
-        {% blocktrans %}Download {{ previous_version }} for macOS 10.5+ (Intel){% endblocktrans %}</a>
-    </p>
-    <p>
-      <a href="{{ previous_osxppc }}"
-         onClick="javascript:trackDownload('{{ previous_osxppc_analytics_conversion }}');">
-        {% blocktrans %}Download {{ previous_version }} for macOS 10.5+ (PPC){% endblocktrans %}</a>
+        {% blocktrans %}Download {{ previous_version }} for macOS {{ previous_macos_min_version }} or later (Intel){% endblocktrans %}</a>
     </p>
 
     <!-- NOTE(rryan): Temporarily hidden while we get back on the Mac App Store -->


### PR DESCRIPTION
Also some proactive changes to make the 2.3.0 beta changes easier.

Do not merge until the release announcement is up on the forum. I'll post that once we have the build servers working again.