### PR TITLE
remove Google Analytics

### DIFF
--- a/content/pages/download.md
+++ b/content/pages/download.md
@@ -12,12 +12,6 @@ unstable_win64: https://downloads.mixxx.org/builds/2.3/Windows/Mixxx-2.3-latest.
 unstable_macosintel: https://downloads.mixxx.org/builds/2.3/macOS/Mixxx-2.3-latest.dmg
 unstable_ubuntu32: https://downloads.mixxx.org/builds/2.3/release/mixxx-2.3.0-beta-2.3-release-bionic-i386-latest.deb
 unstable_ubuntu64: https://downloads.mixxx.org/builds/2.3/release/mixxx-2.3.0-beta-2.3-release-bionic-amd64-latest.deb
-unstable_win32_analytics_conversion: /downloads/2.3.0-beta-win32
-unstable_win64_analytics_conversion: /downloads/2.3.0-beta-win64
-unstable_macosintel_analytics_conversion: /downloads/2.3.0-beta-osxintel
-unstable_ubuntu32_analytics_conversion: /downloads/2.3.0-beta-ubuntu32
-unstable_ubuntu64_analytics_conversion: /downloads/2.3.0-beta-ubuntu64
-unstable_ubuntu_ppa_analytics_conversion: /downloads/2.3.0-beta-ubuntu-ppa
 stable_version: Mixxx 2.2.4
 stable_release_announcement: /news/2020-06-11-Mixxx-2-2-4-released/
 stable_win_min_version: 7
@@ -30,10 +24,3 @@ stable_macosintel: https://downloads.mixxx.org/mixxx-2.2.4/mixxx-2.2.4-osxintel.
 stable_ubuntu32: https://downloads.mixxx.org/mixxx-2.2.4/mixxx-2.2.4-bionic-i386.deb
 stable_ubuntu64: https://downloads.mixxx.org/mixxx-2.2.4/mixxx-2.2.4-bionic-amd64.deb
 stable_linuxsrc: https://github.com/mixxxdj/mixxx/archive/release-2.2.4.tar.gz
-stable_win32_analytics_conversion: /downloads/2.2.4-win32
-stable_win64_analytics_conversion: /downloads/2.2.4-win64
-stable_macosintel_analytics_conversion: /downloads/2.2.4-osxintel
-stable_ubuntu32_analytics_conversion: /downloads/2.2.4-ubuntu-bionic32
-stable_ubuntu64_analytics_conversion: /downloads/2.2.4-ubuntu-bionic64
-stable_ubuntu_ppa_analytics_conversion: NOT YET EXTRACTED, FIX ME BELOW
-stable_linuxsrc_analytics_conversion: /downloads/2.2.4-linuxsrc

--- a/netlify.toml
+++ b/netlify.toml
@@ -49,4 +49,4 @@
   for = "/news/*"
   [headers.values]
     # Additionally allow YouTube/Discourse frames and scripts
-    Content-Security-Policy = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'sha256-UPkidoMErzWw1gW/eY4LhAi9ZkPch3PP31d6KQoJ6Yc=' https://ssl.google-analytics.com/ga.js https://mixxx.discourse.group/javascripts/embed.js *.discourse-cdn.com; frame-src 'self' https://www.youtube-nocookie.com https://mixxx.discourse.group ; img-src 'self' https://i.ytimg.com ; connect-src 'self' https://mixxx.discourse.group https://*.discourse-cdn.com"
+    Content-Security-Policy = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'sha256-UPkidoMErzWw1gW/eY4LhAi9ZkPch3PP31d6KQoJ6Yc=' https://mixxx.discourse.group/javascripts/embed.js *.discourse-cdn.com; frame-src 'self' https://www.youtube-nocookie.com https://mixxx.discourse.group ; img-src 'self' https://i.ytimg.com ; connect-src 'self' https://mixxx.discourse.group https://*.discourse-cdn.com"

--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -74,12 +74,6 @@
       function trackDownload(url) {
         _gaq.push(['_trackPageview', url]);
       }
-
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
     </script>
   </body>
 </html>

--- a/theme/templates/pages/download.html
+++ b/theme/templates/pages/download.html
@@ -25,9 +25,9 @@ sudo apt install mixxx</code></pre>
       <p>{% trans %}Using the PPA ensures that new package versions will be installed automatically with <code>apt</code>. Otherwise, you can download individual packages for {{ os_name }} {{ os_min_version }} or later and install them manually.{% endtrans %}</p>
       {% endif %}
 
-      {% for name, slug, url, analytics_conversion in variants %}
+      {% for name, slug, url in variants %}
       <div>
-        <a class="button button-primary download-{{ slug }}" href="{{ url }}" data-os="{% trans %}{{ os_name }} {{ unstable_win_min_version }} or later ({{ name }}){% endtrans %}" onclick="javascript:trackDownload('{{ analytics_conversion }}');">{% trans %}Download ({{ name }}){% endtrans %}</a>
+        <a class="button button-primary download-{{ slug }}" href="{{ url }}" data-os="{% trans %}{{ os_name }} {{ unstable_win_min_version }} or later ({{ name }}){% endtrans %}">{% trans %}Download ({{ name }}){% endtrans %}</a>
       </div>
       {% endfor %}
 
@@ -133,7 +133,7 @@ sudo apt install mixxx</code></pre>
         os_name="Windows",
         os_min_version=page.unstable_win_min_version,
         variants=[
-          ("64-Bit", "win64", page.unstable_win64, page.unstable_win64_analytics_conversion),
+          ("64-Bit", "win64", page.unstable_win64),
         ]) }}
 
     {# macOS unstable #}
@@ -143,7 +143,7 @@ sudo apt install mixxx</code></pre>
         os_name="macOS",
         os_min_version=page.unstable_macos_min_version,
         variants=[
-          ("Intel", "macosintel", page.unstable_macosintel, page.unstable_macosintel_analytics_conversion),
+          ("Intel", "macosintel", page.unstable_macosintel),
         ]) }}
 
     {# Ubuntu unstable #}
@@ -154,7 +154,7 @@ sudo apt install mixxx</code></pre>
         os_min_version=page.unstable_ubuntu_min_version,
         ppa="mixxxbetas",
         variants=[
-          ("64-Bit", "ubuntu64", page.unstable_ubuntu64, page.unstable_ubuntu64_analytics_conversion),
+          ("64-Bit", "ubuntu64", page.unstable_ubuntu64),
         ]) }}
 
     <div>
@@ -216,8 +216,8 @@ sudo apt install mixxx</code></pre>
         os_name="Windows",
         os_min_version=page.stable_win_min_version,
         variants=[
-          ("32-Bit", "win32", page.stable_win32, page.stable_win32_analytics_conversion),
-          ("64-Bit", "win64", page.stable_win64, page.stable_win64_analytics_conversion),
+          ("32-Bit", "win32", page.stable_win32),
+          ("64-Bit", "win64", page.stable_win64),
         ]) }}
 
     {# macOS stable #}
@@ -226,7 +226,7 @@ sudo apt install mixxx</code></pre>
         os_name="macOS",
         os_min_version=page.stable_macos_min_version,
         variants=[
-          ("Intel", "macosintel", page.stable_macosintel, page.stable_macosintel_analytics_conversion),
+          ("Intel", "macosintel", page.stable_macosintel),
         ]) }}
 
     {# Ubuntu stable #}
@@ -236,8 +236,8 @@ sudo apt install mixxx</code></pre>
         os_min_version=page.stable_ubuntu_min_version,
         ppa="mixxx",
         variants=[
-          ("32-Bit", "ubuntu32", page.stable_ubuntu32, page.stable_ubuntu32_analytics_conversion),
-          ("64-Bit", "ubuntu64", page.stable_ubuntu64, page.stable_ubuntu64_analytics_conversion),
+          ("32-Bit", "ubuntu32", page.stable_ubuntu32),
+          ("64-Bit", "ubuntu64", page.stable_ubuntu64),
         ]) }}
 
 


### PR DESCRIPTION
This proprietary JavaScript collects data about website visitors
without their consent and sends it to an unaccountable third
party. Considering we haven't used the data from it in years, I
do not know why would need to now or in the future. If we really
want this data, we could setup Matomo on the mixxx.org server,
but I do not think this is worth the trouble.