### PR TITLE
Add CSS-only gallery to frontpage

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -9,7 +9,29 @@
 
 <div id="splash">
   <h1>{% trans "DJ Your Way" %}</h1>
-  <img class="center responsive" src="{% static '/static/images/splash-2.1.png' %}">
+
+  <div id="gallery" class="center">
+    <img id="gallery_image1" class="gallery_image" src="{% static '/static/images/feature_skins_deere.png' %}" />
+    <img id="gallery_image2" class="gallery_image" src="{% static '/static/images/feature_skins_latenight.png' %}" />
+    <img id="gallery_image3" class="gallery_image" src="{% static '/static/images/feature_skins_shade.png' %}" />
+    <img id="gallery_image4" class="gallery_image" src="{% static '/static/images/feature_skins_tango.png' %}" />
+  </div>
+
+  <div id="gallery_thumbnails">
+    <a href="#gallery_image1">
+      <img class="gallery_thumbnail" src="{% static '/static/images/feature_skins_deere.png' %}" />
+    </a>
+    <a href="#gallery_image2">
+      <img class="gallery_thumbnail" src="{% static '/static/images/feature_skins_latenight.png' %}" />
+    </a>
+    <a href="#gallery_image3">
+      <img class="gallery_thumbnail" src="{% static '/static/images/feature_skins_shade.png' %}" />
+    </a>
+    <a href="#gallery_image4">
+      <img class="gallery_thumbnail" src="{% static '/static/images/feature_skins_tango.png' %}" />
+    </a>
+  </div>
+
 </div>
 {% endblock %}
 

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -269,13 +269,36 @@ p#navbar_tinylinks
     padding-top: 5px;
     padding-bottom: 15px;
     background-color: #000000;
-    text-align: center;
 }
 
-#splash img
+#gallery
 {
-    height: auto;
-    width: 676px;
+    display: flex;
+    flex-direction: row;
+    overflow-x: hidden;
+    width: 445px;
+    max-width: 100%;
+    margin: auto;
+}
+
+.gallery_image
+{
+    display: flex;
+    max-width: 100%;
+}
+
+#gallery_thumbnails
+{
+    display: flex;
+    overflow-x: auto;
+    width: 100%;
+    margin: auto;
+    margin-top: 10px;
+}
+
+.gallery_thumbnail
+{
+    width: 200px;
 }
 
 .gapfiller


### PR DESCRIPTION
https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Website.20splash.20image.20gallery

This is a quick attempt without any JS.
Clicking on a thumbnail image navigates the browser to the regarding `#` anchor marker. This causes the large image container to scroll to the correct position to show the image.
I couldn't figure out how to center the thumbnails while keeping the ability to correctly scroll horizontally through the thumbnails on smaller screens. Input is appreciated.

`justify-content: center`, `margin: auto` and `width: fit-content` in various combinations either prevented the scrolling or didn't allow to scroll completly to the left.

This uses the screenshots I found were used on the feature site.

Large screen:
![127 0 0 1_8000_ (2)](https://user-images.githubusercontent.com/10366256/81510634-94e63d00-9313-11ea-96ff-762fbc568e47.png)

Smaller screen:
![127 0 0 1_8000_(Galaxy S5)](https://user-images.githubusercontent.com/10366256/81510637-99aaf100-9313-11ea-9b65-6a5a560d82db.png)
