### PR TITLE
Added gallery to frontpage

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -4,12 +4,41 @@
 
 {% block title %}{% trans "Free DJ Mixing Software App" %}{% endblock %}
 
+{% block extra_script %}
+<script type="text/javascript" src="{% static '/static/js/gallery.js' %}"></script>
+<script type="text/javascript">
+  const images = [
+    "{% static '/static/images/feature_skins_deere.png' %}",
+    "{% static '/static/images/feature_skins_latenight.png' %}",
+    "{% static '/static/images/feature_skins_shade.png' %}",
+    "{% static '/static/images/feature_skins_tango.png' %}"
+  ];
+
+  // Unhide the navigation buttons. Those are hidden by default if JS is disabled and no navigation is possible.
+  // The buttons itself don't have a click listener, they just guide the user to click on the image.
+  const previousImageButton = document.getElementById("previous_image_button");
+  const nextImageButton = document.getElementById("next_image_button");
+  previousImageButton.style.display = "initial";
+  nextImageButton.style.display = "initial";
+
+  const splashGallery = document.getElementById("splash_gallery");
+  const splashImg = document.getElementById("splash_img");
+  setupGallery(splashGallery, splashImg, images);
+</script>
+{% endblock %}
+
 {% block after_navbar %}
 {% include "social_sidebar.html" %}
 
 <div id="splash">
-  <h1>{% trans "DJ Your Way" %}</h1>
-  <img class="center responsive" src="{% static '/static/images/splash-2.1.png' %}">
+  <h1 class="center">{% trans "DJ Your Way" %}</h1>
+
+  <div id="splash_gallery">
+    <!-- Setup the gallery in a way that still makes sense even if JS is disabled: Set default image and hide navigation buttons (displayed by JS again) -->
+    <img id="splash_img" src="{% static '/static/images/feature_skins_deere.png' %}">
+    <img id="previous_image_button" class="gallery_navigation_button" style="display: none;" src="{% static '/static/images/arrow_left.svg' %}" />
+    <img id="next_image_button" class="gallery_navigation_button" style="display: none;" src="{% static '/static/images/arrow_right.svg' %}" />
+  </div>
 </div>
 {% endblock %}
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -7,13 +7,6 @@
 {% block extra_script %}
 <script type="text/javascript" src="{% static '/static/js/gallery.js' %}"></script>
 <script type="text/javascript">
-  const images = [
-    "{% static '/static/images/feature_skins_deere.png' %}",
-    "{% static '/static/images/feature_skins_latenight.png' %}",
-    "{% static '/static/images/feature_skins_shade.png' %}",
-    "{% static '/static/images/feature_skins_tango.png' %}"
-  ];
-
   // Unhide the navigation buttons. Those are hidden by default if JS is disabled and no navigation is possible.
   // The buttons itself don't have a click listener, they just guide the user to click on the image.
   const previousImageButton = document.getElementById("previous_image_button");
@@ -22,8 +15,9 @@
   nextImageButton.style.display = "initial";
 
   const splashGallery = document.getElementById("splash_gallery");
-  const splashImg = document.getElementById("splash_img");
-  setupGallery(splashGallery, splashImg, images);
+  const splashImages = document.getElementsByClassName("splash_img_non_js");
+
+  setupGallery(splashGallery, splashImages);
 </script>
 {% endblock %}
 
@@ -35,7 +29,11 @@
 
   <div id="splash_gallery" class="responsive">
     <!-- Setup the gallery in a way that still makes sense even if JS is disabled: Set default image and hide navigation buttons (displayed by JS again) -->
-    <img id="splash_img" class="responsive" src="{% static '/static/images/feature_skins_deere.png' %}">
+    <img class="splash_img splash_img_non_js splash_img_dimensions responsive" src="{% static '/static/images/feature_skins_deere.png' %}">
+    <img class="splash_img splash_img_non_js splash_img_dimensions splash_img_hidden splash_img_hidden_non_js responsive" src="{% static '/static/images/feature_skins_latenight.png' %}">
+    <img class="splash_img splash_img_non_js splash_img_dimensions splash_img_hidden splash_img_hidden_non_js responsive" src="{% static '/static/images/feature_skins_shade.png' %}">
+    <img class="splash_img splash_img_non_js splash_img_dimensions splash_img_hidden splash_img_hidden_non_js responsive" src="{% static '/static/images/feature_skins_tango.png' %}">
+
     <img id="previous_image_button" class="gallery_navigation_button" style="display: none;" src="{% static '/static/images/arrow_left.svg' %}" />
     <img id="next_image_button" class="gallery_navigation_button" style="display: none;" src="{% static '/static/images/arrow_right.svg' %}" />
   </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -30,12 +30,12 @@
 {% block after_navbar %}
 {% include "social_sidebar.html" %}
 
-<div id="splash">
+<div id="splash" class="responsive">
   <h1 class="center">{% trans "DJ Your Way" %}</h1>
 
-  <div id="splash_gallery">
+  <div id="splash_gallery" class="responsive">
     <!-- Setup the gallery in a way that still makes sense even if JS is disabled: Set default image and hide navigation buttons (displayed by JS again) -->
-    <img id="splash_img" src="{% static '/static/images/feature_skins_deere.png' %}">
+    <img id="splash_img" class="responsive" src="{% static '/static/images/feature_skins_deere.png' %}">
     <img id="previous_image_button" class="gallery_navigation_button" style="display: none;" src="{% static '/static/images/arrow_left.svg' %}" />
     <img id="next_image_button" class="gallery_navigation_button" style="display: none;" src="{% static '/static/images/arrow_right.svg' %}" />
   </div>

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -269,13 +269,34 @@ p#navbar_tinylinks
     padding-top: 5px;
     padding-bottom: 15px;
     background-color: #000000;
-    text-align: center;
 }
 
-#splash img
-{
+#splash_gallery {
+    position: relative;
+    width: 445px;
+    height: 250px;
+    text-align: left;
+    margin: auto;
+}
+
+#splash_img {
+    position: absolute;
+}
+
+.gallery_navigation_button {
+    position: absolute;
+    width: 15px;
     height: auto;
-    width: 676px;
+    top: 50%;
+    transform: translateY(-50%); /* Effectively sets the origin of the element to its center */
+}
+
+#previous_image_button {
+    left: 5px;
+}
+
+#next_image_button {
+    right: 5px;
 }
 
 .gapfiller

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -48,7 +48,7 @@ img
     border: 0;
 }
 
-img.responsive
+.responsive
 {
     max-width: 100%;
 }
@@ -271,31 +271,31 @@ p#navbar_tinylinks
     background-color: #000000;
 }
 
-#splash_gallery {
+#splash_gallery
+{
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     position: relative;
     width: 445px;
     height: 250px;
-    text-align: left;
     margin: auto;
 }
 
-#splash_img {
-    position: absolute;
-}
-
-.gallery_navigation_button {
+.gallery_navigation_button
+{
     position: absolute;
     width: 15px;
     height: auto;
-    top: 50%;
-    transform: translateY(-50%); /* Effectively sets the origin of the element to its center */
 }
 
-#previous_image_button {
+#previous_image_button
+{
     left: 5px;
 }
 
-#next_image_button {
+#next_image_button
+{
     right: 5px;
 }
 

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -277,16 +277,19 @@ p#navbar_tinylinks
     flex-direction: column;
     justify-content: center;
     position: relative;
-    width: 445px;
-    height: 250px;
+    width: 670px;
     margin: auto;
+}
+
+#splash_img 
+{
+    width: 100%;
 }
 
 .gallery_navigation_button
 {
     position: absolute;
     width: 15px;
-    height: auto;
 }
 
 #previous_image_button

--- a/static/css/mixxx.css
+++ b/static/css/mixxx.css
@@ -1,5 +1,11 @@
 @charset "utf-8";
 
+:root
+{
+    --splash_img_original_width: 445px;
+    --splash_img_original_height: 250px;
+}
+
 /* styles for html, body and wrapper */
 html, body
 {
@@ -277,13 +283,39 @@ p#navbar_tinylinks
     flex-direction: column;
     justify-content: center;
     position: relative;
-    width: 670px;
     margin: auto;
 }
 
-#splash_img 
+.splash_img_dimensions
 {
-    width: 100%;
+    width: calc(var(--splash_img_original_width) * 1.5);
+}
+
+.splash_img
+{
+    left: 50%; /* Centers the absolute element */
+    transform: translateX(-50%); /* Effectively sets the origin to the the center of the X-axis */
+}
+
+.splash_img_non_js
+{
+    position: relative;
+}
+
+.splash_img_with_js 
+{
+    position: absolute;
+    transition: opacity 1s;
+}
+
+.splash_img_hidden
+{
+    opacity: 0;
+}
+
+.splash_img_hidden_non_js
+{
+    display: none;
 }
 
 .gallery_navigation_button

--- a/static/images/arrow_left.svg
+++ b/static/images/arrow_left.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="50">
+  <polyline points="25,5 5,25 25,45" stroke = "white" fill="none" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" />
+</svg>

--- a/static/images/arrow_right.svg
+++ b/static/images/arrow_right.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="50">
+  <polyline points="5,5 25,25 5,45" stroke = "white" fill="none" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" />
+</svg>

--- a/static/js/gallery.js
+++ b/static/js/gallery.js
@@ -1,0 +1,26 @@
+function setupGallery(galleryContainer, imgElement, images) {
+  let imageIndex = 0;
+
+  function setImage(indexChange) {
+    imageIndex = posMod(imageIndex + indexChange, images.length);
+    imgElement.src = images[imageIndex];
+  }
+
+  // start autoplay
+  const intervalId = setInterval(function () { setImage(+1) }, 5000);
+
+  galleryContainer.addEventListener("click", function (event) {
+    clearInterval(intervalId); // stop autoplay
+
+    const imgBoundingRect = galleryContainer.getBoundingClientRect();
+    const imgCenterX = imgBoundingRect.x + imgBoundingRect.width / 2;
+    const clickedOnLeftSide = event.clientX < imgCenterX;
+
+    const changeBy = clickedOnLeftSide ? -1 : 1;
+    setImage(changeBy);
+  });
+}
+
+function posMod(n, m) {
+  return ((n % m) + m) % m;
+}

--- a/static/js/gallery.js
+++ b/static/js/gallery.js
@@ -1,13 +1,42 @@
-function setupGallery(galleryContainer, imgElement, images) {
+function setupGallery(galleryContainer, imgElements) {
+  // copy the HTMLCollection to an array
+  // manipulating the classList later on also affects the HTMLCollection, which we don't want
+  const imgElementsArray = Array.from(imgElements);
   let imageIndex = 0;
 
+  const computedStyle = getComputedStyle(galleryContainer);
+  const originalWidth = computedStyle.getPropertyValue("--splash_img_original_width").trim().replace("px", "");
+  const originalHeight = computedStyle.getPropertyValue("--splash_img_original_height").trim().replace("px", "");;
+
+  const scaleFactor = imgElements[0].offsetWidth / originalWidth;
+  const newHeight = scaleFactor * originalHeight;
+
+  galleryContainer.style.width = imgElements[0].offsetWidth + "px";
+  galleryContainer.style.height = newHeight + "px";
+
+  for (const img of Array.from(imgElementsArray)) {
+    img.classList.remove("splash_img_non_js");
+    img.classList.remove("splash_img_hidden_non_js");
+    img.classList.add("splash_img_with_js");
+
+    img.style.height = newHeight + "px";
+  }
+
   function setImage(indexChange) {
-    imageIndex = posMod(imageIndex + indexChange, images.length);
-    imgElement.src = images[imageIndex];
+    if (indexChange != -1 && indexChange != +1) {
+      throw new Error("Argument 'indexChange' must be -1 or +1!");
+    }
+
+    const oldImage = imgElementsArray[imageIndex];
+    imageIndex = posMod(imageIndex + indexChange, imgElementsArray.length);
+    const newImage = imgElementsArray[imageIndex];
+    
+    oldImage.classList.add("splash_img_hidden");
+    newImage.classList.remove("splash_img_hidden");
   }
 
   // start autoplay
-  const intervalId = setInterval(function () { setImage(+1) }, 5000);
+  const intervalId = 0//setInterval(function () { setImage(+1) }, 5000);
 
   galleryContainer.addEventListener("click", function (event) {
     clearInterval(intervalId); // stop autoplay


### PR DESCRIPTION
This is a rework of #87.
The gallery cycles through the four images I found in this repo, with each image having 5 seconds. Once the user clicks on the gallery the autoplay stops. The arrows on the gallery don't have to be clicked exactly: Clicking on the left halve of the whole image navigates you one back, right halve is next image.
I had some fun with svg and created the arrows myself.
This is the most minimal state of how it could be implemented, you could add sliding transitions, titles, page indicators, fullscreen images, etc.