### PR TITLE
Build website on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python:
+- 3.7
+os: linux
+dist: xenial
+cache:
+  pip: true
+
+install:
+- python -m pip install -r requirements.txt
+
+script:
+- cactus build --verbose
+- cd .build
+- find .


### PR DESCRIPTION
This will make us less dependent on the build server (and should also free up the build queue a bit).

- [X] Build website on Travis CI
- [ ] Enable Travis CI for this repository
- [ ] Add deploy configuration, e.g. using rsync (@rryan I need SSH access to the server though. Maybe you can generate an SSH keypair that only allows access to the webserver docroot?)
  We can then [encrypt the SSH key](https://docs.travis-ci.com/user/encrypting-files/) and only decrypt it when a master build passed and we want to deploy.