### PR TITLE
Do not direct users to Zulip for support

### DIFF
--- a/pages/contact.html
+++ b/pages/contact.html
@@ -8,7 +8,7 @@
 <div id="get-in-touch" class="docs-section container">
   <h1><a class="headline-link" href="#get-in-touch">{% trans "Get in Touch" %}</a></h1>
   <p>
-    {% blocktrans with forums_link="/forums" zulip_web_link="https://mixxx.zulipchat.com/" support_page_link="/support" bug_tracker_link="https://bugs.launchpad.net/mixxx/" %}Support for users of Mixxx is available through our <a href="{{ forums_link }}">community forums</a> and our <a href="{{ zulip_web_link }}">Zulip chat</a> as described on our <a href="{{ support_page_link }}">Support page</a>. If you think you've found a bug, please file a bug report in our <a href="{{ bug_tracker_link }}">bug tracker</a>. If you would like to get in touch with Mixxx developers, Zulip is the best way to reach us.{% endblocktrans %}
+    {% blocktrans with support_page_link="/support" bug_tracker_link="https://bugs.launchpad.net/mixxx/" %}Please refer to the <a href="{{ support_page_link }}">Support page</a> if you need help setting up or using Mixxx. If you think you've found a bug, please file a bug report in our <a href="{{ bug_tracker_link }}">bug tracker</a>. If you would like to get in touch with Mixxx developers, <a href="{{ zulip_web_link }}">Zulip</a> is the best way to reach us.{% endblocktrans %}
   </p>
   <p>
     {% blocktrans with project_manager_link="mailto:hardware@mixxx.org" %}If you're a DJ hardware manufacturer and would like your product to work with Mixxx, please contact us at, <a href="{{ project_manager_link }}">hardware@mixxx.org</a>. We accept donations and loans of DJ equipment which we use to improve both specific and general hardware support in Mixxx.{% endblocktrans %}

--- a/pages/get-involved.html
+++ b/pages/get-involved.html
@@ -24,7 +24,7 @@
       <h6 class="docs-header">{% trans "Start Developing Now" %}</h6>
       <ul>
         <li>
-            {% blocktrans with zulip_web_link="https://mixxx.zulipchat.com/" %}Introduce yourself to the community on our <a href="{{ zulip_web_link }}">Zulip chat</a>.{% endblocktrans %}
+            {% blocktrans with zulip_web_link="https://mixxx.zulipchat.com/#narrow/stream/109123-introduce-yourself" %}Introduce yourself to the community on our <a href="{{ zulip_web_link }}">Zulip chat</a>.{% endblocktrans %}
         </li>
         <li>
             {% blocktrans with com_github_link="https://github.com" using_git_wiki_link="https://github.com/mixxxdj/mixxx/wiki/using_git" %}Get a <a href="{{ com_github_link }}">Github</a> account and <a href="{{ using_git_wiki_link }} ">fork your own branch</a>!{% endblocktrans %}

--- a/pages/get-involved.html
+++ b/pages/get-involved.html
@@ -24,13 +24,13 @@
       <h6 class="docs-header">{% trans "Start Developing Now" %}</h6>
       <ul>
         <li>
+            {% blocktrans with zulip_web_link="https://mixxx.zulipchat.com/" %}Introduce yourself to the community on our <a href="{{ zulip_web_link }}">Zulip chat</a>.{% endblocktrans %}
+        </li>
+        <li>
             {% blocktrans with com_github_link="https://github.com" using_git_wiki_link="https://github.com/mixxxdj/mixxx/wiki/using_git" %}Get a <a href="{{ com_github_link }}">Github</a> account and <a href="{{ using_git_wiki_link }} ">fork your own branch</a>!{% endblocktrans %}
         </li>
         <li>
             {% blocktrans with easy_bug_list_link="https://bugs.launchpad.net/mixxx/+bugs?field.tag=easy" mixxx_credits_link="/contact/" %}Pick a bug off our <a href="{{ easy_bug_list_link }} ">Easy Bugs List</a> and start hacking!<br><br> Fixed it? Your name will be in the <a href="{{ mixxx_credits_link }}">Mixxx credits</a>!{% endblocktrans %}
-        </li>
-        <li>
-            {% blocktrans with zulip_web_link="https://mixxx.zulipchat.com/" %}When you're stuck, get help from our existing developers on <a href="{{ zulip_web_link }}">Zulip chat</a>{% endblocktrans %}
         </li>
         <li>
             {% blocktrans with mailing_list_link="https://lists.sourceforge.net/lists/listinfo/mixxx-devel" %}Join our mailing list: <a href="{{ mailing_list_link }}">mixxx-devel</a>{% endblocktrans %}

--- a/pages/get-involved.html
+++ b/pages/get-involved.html
@@ -61,7 +61,7 @@
           {% blocktrans with mixxx_wiki_link="/wiki/" %}Help keep our <a href="{{ mixxx_wiki_link }}">Wiki</a> up-to-date.{% endblocktrans %}
         </li>
         <li>
-          {% blocktrans with forum_link="https://mixxx.discourse.group/" zulip_web_link="https://mixxx.zulipchat.com/" %}Support other DJs with their technical questions on <a href="{{ forum_link }}">the forums</a> and <a href="{{ zulip_web_link }}">Zulip</a>.{% endblocktrans %}
+          {% blocktrans with forum_link="https://mixxx.discourse.group/" %}Support other DJs with their technical questions on <a href="{{ forum_link }}">the forums</a>.{% endblocktrans %}
         </li>
         <li>
           <b>{% trans "Promote Mixxx:" %} </b>{% blocktrans %}Write an article about how you use Mixxx for your blog, or mention us when new releases come out. Any exposure on the web and in print helps our project grow, and is much appreciated!{% endblocktrans %}

--- a/pages/get-involved.html
+++ b/pages/get-involved.html
@@ -33,9 +33,6 @@
             {% blocktrans with easy_bug_list_link="https://bugs.launchpad.net/mixxx/+bugs?field.tag=easy" mixxx_credits_link="/contact/" %}Pick a bug off our <a href="{{ easy_bug_list_link }} ">Easy Bugs List</a> and start hacking!<br><br> Fixed it? Your name will be in the <a href="{{ mixxx_credits_link }}">Mixxx credits</a>!{% endblocktrans %}
         </li>
         <li>
-            {% blocktrans with mailing_list_link="https://lists.sourceforge.net/lists/listinfo/mixxx-devel" %}Join our mailing list: <a href="{{ mailing_list_link }}">mixxx-devel</a>{% endblocktrans %}
-        </li>
-        <li>
             {% blocktrans %}You don't even have to know C++. There are developers who got into Mixxx development while learning C++ along the way.{% endblocktrans %}
         </li>
       </ul>

--- a/pages/support.html
+++ b/pages/support.html
@@ -31,13 +31,6 @@
     </div>
 
     <div>
-      <h5>{% trans "Mailing List" %}</h5>
-      <p>
-        {% blocktrans with mailing_list_link="https://lists.sourceforge.net/lists/listinfo/mixxx-devel" sourceforge_archive_link="https://sourceforge.net/p/mixxx/mailman/mixxx-devel/" the_mail_archive_link="https://www.mail-archive.com/mixxx-devel@lists.sourceforge.net/" %}The <a href="{{ mailing_list_link}} ">mixxx-devel</a> mailing list (<a href="{{ sourceforge_archive_link }}">SourceForge</a> and <a href="{{ the_mail_archive_link }}">The Mail Archive</a> archives) is now a low-traffic, mostly announcement channel. Subscribe if you would like to be informed about new releases and other topics.{% endblocktrans %}
-      </p>
-    </div>
-
-    <div>
       <h5>{% trans "Bug Tracker" %}</h5>
       <p>
         {% blocktrans with bug_tracker_link="https://bugs.launchpad.net/mixxx/" %}Please report any bugs you find to our <a href=" {{ bug_tracker_link }}">Bug Tracker</a>. The bug tracker gives us a centralized place to pool our information on bugs, and prevents us from getting disorganized and forgetting about them.{% endblocktrans %}

--- a/pages/support.html
+++ b/pages/support.html
@@ -26,7 +26,7 @@
     <div>
       <h5>{% trans "Community Forums" %}</h5>
       <p>
-        {% blocktrans with forums_link="/forums" %}Have a Mixxx-related question? Something other DJs can help you with? Ask in the <a href="{{ forums_link }}">Mixxx Community Forums</a>. This is also the place to find or share additional controller mappings, keyboard mappings, skin and script tweaks. You may also post your mixes and promote your upcoming gigs there. {% endblocktrans %}
+        {% blocktrans with forums_link="https://mixxx.discourse.group/" %}If you need help setting up or using Mixxx, ask in the <a href="{{ forums_link }}">Mixxx Community Forums</a>. This is also the place to find or share unofficial controller mappings, keyboard mappings, and skins.{% endblocktrans %}
       </p>
     </div>
 

--- a/pages/support.html
+++ b/pages/support.html
@@ -31,13 +31,6 @@
     </div>
 
     <div>
-      <h5>{% trans "Zulip Chat" %}</h5>
-      <p>
-        {% blocktrans with zulip_web_link="https://mixxx.zulipchat.com/" zulip_app_link="https://zulipchat.com/apps/" %}<a href="{{ zulip_web_link }}">Mixxx's Zulip chat instance</a> is a fun place to hang out with the developers and meet some fellow DJs. Here, the Mixxx team discusses upcoming changes and programming related stuff. It can be used for support too. Join the discussion <a href="{{ zulip_web_link }} ">on the web</a> or download the <a href="{{ zulip_app_link }}">Zulip app</a> and configure it to use the server mixxx.zulipchat.com. {% endblocktrans %}
-      </p>
-    </div>
-
-    <div>
       <h5>{% trans "Mailing List" %}</h5>
       <p>
         {% blocktrans with mailing_list_link="https://lists.sourceforge.net/lists/listinfo/mixxx-devel" sourceforge_archive_link="https://sourceforge.net/p/mixxx/mailman/mixxx-devel/" the_mail_archive_link="https://www.mail-archive.com/mixxx-devel@lists.sourceforge.net/" %}The <a href="{{ mailing_list_link}} ">mixxx-devel</a> mailing list (<a href="{{ sourceforge_archive_link }}">SourceForge</a> and <a href="{{ the_mail_archive_link }}">The Mail Archive</a> archives) is now a low-traffic, mostly announcement channel. Subscribe if you would like to be informed about new releases and other topics.{% endblocktrans %}


### PR DESCRIPTION
Zulip is now mentioned only on the Get Involved and Contact pages.