### PR TITLE
Netlify: Improve redirects

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,16 @@
-/manual/* https://holzhaus-mixxx-manual.netlify.app/:splat 302
-/*        /error/                                          404
+# Redirects for the Mixxx website
+# See https://docs.netlify.com/routing/redirects/ for details.
+
+# Redirect www.mixxx.org subdomain to plain mixxx.org
+http://www.mixxx.org/*  https://mixxx.org/:splat                301!
+https://www.mixxx.org/* https://mixxx.org/:splat                301!
+
+# Redirect manual
+# TODO: Replace this with manual.mixxx.org when the domain name has been mapped
+/manual/*               https://mixxx-manual.netlify.app/:splat 301!
+
+# Redirect links to old forum posts
+/forums/*               https://mixxx.discourse.group/:splat    301!
+
+# Error page
+/*                      /error/                                 404


### PR DESCRIPTION
This won't fix the error that @daschuer [reported on Zulip](https://mixxx.zulipchat.com/#narrow/stream/109176-documentation/topic/Comments.20on.20Website.20news.20posts/near/203493062) because we're not using Netlify for mixxx.org yet.

For now, the redirect also need to be fixed on our current webserver and that doesn't seem to be possible via the git repository.
@RJ could you add a rule that redirects everything from www.mixxx.org to mixxx.org?