### PR TITLE
Replaced obsolete Windows builds with link to nightly builds

### DIFF
--- a/pages/download.html
+++ b/pages/download.html
@@ -8,8 +8,8 @@ unstable_win_min_version: 7
 unstable_macos_min_version: 10.11
 unstable_ubuntu_min_version: 18.04 (Bionic)
 unstable_git_branch: 2.3
-unstable_win32: http://downloads.mixxx.org/builds/2.3/release/mixxx-2.3.0-beta-2.3-release-x86-latest.exe
-unstable_win64: http://downloads.mixxx.org/builds/2.3/release/mixxx-2.3.0-beta-2.3-release-x64-latest.exe
+unstable_win32: https://downloads.mixxx.org/builds/appveyor/cmake_build/?C=M;O=D
+unstable_win64: https://downloads.mixxx.org/builds/appveyor/cmake_build/?C=M;O=D
 unstable_osxintel: http://downloads.mixxx.org/builds/2.3/release/mixxx-2.3.0-beta-2.3-release-macintel64-latest.dmg
 unstable_ubuntu32: http://downloads.mixxx.org/builds/2.3/release/mixxx-2.3.0-beta-2.3-release-bionic-i386-latest.deb
 unstable_ubuntu64: http://downloads.mixxx.org/builds/2.3/release/mixxx-2.3.0-beta-2.3-release-bionic-amd64-latest.deb


### PR DESCRIPTION
by https://downloads.mixxx.org/builds/appveyor/cmake_build/?C=M;O=D
according to https://bugs.launchpad.net/mixxx/+bug/1898586