### PR TITLE
pages/download: Add Development snapshot section

### DIFF
--- a/pages/download.html
+++ b/pages/download.html
@@ -317,8 +317,7 @@ sudo apt install mixxx</code></pre>
     Additionally, we also provide development snapshots for <a href="{{ windows_snapshot_link }}">Windows</a>,  <a href="{{ macos_snapshot_link }}">macOS</a> and <a href="{{ ubuntu_snapshot_link }}">Ubuntu</a>.{% endblocktrans %}
   </p>
   <p>
-    {% blocktrans %}Some developers choose to use the main branch for performance and new features.
-    Every change is peer reviewed, however, it is more likely that new bugs will be found on the main branch than stable or beta releases.
+    {% blocktrans %}Every change is peer reviewed, however, it is more likely that new bugs will be found on the main branch than stable or beta releases.
     For most users, we recommend using the mature <a href="#stable">stable</a> version.{% endblocktrans %}
   </p>
 </div>

--- a/pages/download.html
+++ b/pages/download.html
@@ -309,6 +309,15 @@ sudo apt install mixxx</code></pre>
   </div>
 </div>
 
+<div id="snapshots" class="docs-section container">
+  <h2><a class="headline-link" href="#snapshots">{% blocktrans %}Development Snapshots{% endblocktrans %}</a></h2>
+  <p>
+    {% blocktrans with source_link="https://github.com/mixxxdj/mixxx" windows_snapshot_link="https://downloads.mixxx.org/builds/appveyor/cmake_build/" macos_snapshot_link="https://downloads.mixxx.org/builds/travis/main/" ubuntu_snapshot_link="https://downloads.mixxx.org/builds/travis/main/" %}Want to test and experiment with the latest changes?
+    The best way to keep up with Mixxx development is to grab the <a href="{{ source_link }}">source code</a> and compile Mixxx yourself.
+    Additionally, we also provide development snapshots for <a href="{{ windows_snapshot_link }}">Windows</a>,  <a href="{{ macos_snapshot_link }}">macOS</a> and <a href="{{ ubuntu_snapshot_link }}">Ubuntu</a>.{% endblocktrans %}
+  </p>
+</div>
+
 <div id="previous" class="docs-section container">
   <h2><a class="headline-link" href="#previous">{% blocktrans %}Previous Mixxx Versions{% endblocktrans %}</a></h2>
   <p>

--- a/pages/download.html
+++ b/pages/download.html
@@ -314,7 +314,7 @@ sudo apt install mixxx</code></pre>
   <p>
     {% blocktrans with source_link="https://github.com/mixxxdj/mixxx" windows_snapshot_link="https://downloads.mixxx.org/builds/appveyor/cmake_build/" macos_snapshot_link="https://downloads.mixxx.org/builds/travis/main/" ubuntu_snapshot_link="https://downloads.mixxx.org/builds/travis/main/" %}Want to test and experiment with the latest changes?
     The best way to keep up with Mixxx development is to grab the <a href="{{ source_link }}">source code</a> and compile Mixxx yourself.
-    Additionally, we also provide development snapshots for <a href="{{ windows_snapshot_link }}">Windows</a>,  <a href="{{ macos_snapshot_link }}">macOS</a> and <a href="{{ ubuntu_snapshot_link }}">Ubuntu</a>.{% endblocktrans %}
+    Additionally, we provide pre-built development snapshots for <a href="{{ windows_snapshot_link }}">Windows</a>,  <a href="{{ macos_snapshot_link }}">macOS</a> and <a href="{{ ubuntu_snapshot_link }}">Ubuntu</a>.{% endblocktrans %}
   </p>
   <p>
     {% blocktrans %}Every change is peer reviewed, however, it is more likely that new bugs will be found on the main branch than stable or beta releases.

--- a/pages/download.html
+++ b/pages/download.html
@@ -312,7 +312,7 @@ sudo apt install mixxx</code></pre>
 <div id="snapshots" class="docs-section container">
   <h2><a class="headline-link" href="#snapshots">{% blocktrans %}Development Snapshots{% endblocktrans %}</a></h2>
   <p>
-    {% blocktrans with source_link="https://github.com/mixxxdj/mixxx" windows_snapshot_link="https://downloads.mixxx.org/builds/appveyor/cmake_build/" macos_snapshot_link="https://downloads.mixxx.org/builds/travis/main/" ubuntu_snapshot_link="https://downloads.mixxx.org/builds/travis/main/" %}Want to test and experiment with the latest changes?
+    {% blocktrans with source_link="https://github.com/mixxxdj/mixxx" windows_snapshot_link="https://downloads.mixxx.org/builds/appveyor/cmake_build/?C=M;O=D" macos_snapshot_link="https://downloads.mixxx.org/builds/travis/main/?C=M;O=D" ubuntu_snapshot_link="https://downloads.mixxx.org/builds/travis/main/?C=M;O=D" %}Want to test and experiment with the latest changes?
     The best way to keep up with Mixxx development is to grab the <a href="{{ source_link }}">source code</a> and compile Mixxx yourself.
     Additionally, we provide pre-built development snapshots for <a href="{{ windows_snapshot_link }}">Windows</a>,  <a href="{{ macos_snapshot_link }}">macOS</a> and <a href="{{ ubuntu_snapshot_link }}">Ubuntu</a>.{% endblocktrans %}
   </p>

--- a/pages/download.html
+++ b/pages/download.html
@@ -316,6 +316,11 @@ sudo apt install mixxx</code></pre>
     The best way to keep up with Mixxx development is to grab the <a href="{{ source_link }}">source code</a> and compile Mixxx yourself.
     Additionally, we also provide development snapshots for <a href="{{ windows_snapshot_link }}">Windows</a>,  <a href="{{ macos_snapshot_link }}">macOS</a> and <a href="{{ ubuntu_snapshot_link }}">Ubuntu</a>.{% endblocktrans %}
   </p>
+  <p>
+    {% blocktrans %}Some developers choose to use the main branch for performance and new features.
+    Every change is peer reviewed, however, it is more likely that new bugs will be found on the main branch than stable or beta releases.
+    For most users, we recommend using the mature <a href="#stable">stable</a> version.{% endblocktrans %}
+  </p>
 </div>
 
 <div id="previous" class="docs-section container">


### PR DESCRIPTION
Resolves #156 without making downloading the latest version more
complicated for regular users.

Maybe this is a good compromise for the different opinions stated in https://bugs.launchpad.net/mixxx/+bug/1898586.