### PR TITLE
GitHub Actions: Automatically fill in blog post date after merge

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -20,9 +20,17 @@ jobs:
         python-version: 3.9
     - name: Update dates of news posts
       run: tools/update_news_date.py -b website pages/news/
+    - name: Check if changes any changes were made
+      run: echo "GIT_DIRTY=$(git diff --quiet ; printf "%d" "$?")" >> "${GITHUB_ENV}"
     - uses: EndBug/add-and-commit@v5
+      if: env.GIT_DIRTY != null && env.GIT_DIRTY != '0'
       with:
         add: 'pages/news'
         message: 'pages/news: Update blog post date after merge'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Trigger Netlify build
+      if: env.NETLIFY_BUILD_HOOK != null && env.GIT_DIRTY != null && env.GIT_DIRTY != '0'
+      run: curl -X POST -d {} ${{ env.NETLIFY_BUILD_HOOK }}
+      env:
+        NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,28 @@
+name: website
+
+on:
+  push:
+    branches:
+      - website
+
+jobs:
+  update-news-date:
+    name: Update post news date
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Update dates of news posts
+      run: tools/update_news_date.py -b website pages/news/
+    - uses: EndBug/add-and-commit@v5
+      with:
+        add: 'pages/news'
+        message: 'pages/news: Update blog post date after merge'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/plugins/news.py
+++ b/plugins/news.py
@@ -146,6 +146,15 @@ def preBuild(site):
                     postContext["date"], "%Y-%m-%d"
                 )
             except Exception as e:
+                # If this is a Netlify deploy preview, include this post even
+                # though the date is not properly formatted. If it's a branch
+                # deploy, skip it. GitHub actions will replace placeholder
+                # dates automatically trigger a new deploy.
+                # This prevents posts from showing up with the wrong URL/date
+                # before GitHub action is finished.
+                if os.getenv("CONTEXT") != "deploy-preview":
+                    continue
+
                 postContext["date"] = datetime.datetime.now()
                 logging.warning(
                     "Date format not correct for page %s, "

--- a/tools/update_news_date.py
+++ b/tools/update_news_date.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+import argparse
+import datetime
+import os
+import re
+import subprocess
+import sys
+
+RE_POST_DATE = re.compile(r"^date:\s+(.*)$", flags=re.MULTILINE)
+
+
+def find_commit_that_added_file(path: str, format: str = "oneline"):
+    lines = subprocess.check_output(
+        (
+            "git",
+            "log",
+            "--follow",
+            "--diff-filter=A",
+            f"--pretty={format}",
+            "--",
+            path,
+        ),
+        encoding="utf-8",
+    ).splitlines()
+    return lines[-1].strip()
+
+
+def find_merge_commit_to_branch(commit: str, branch: str):
+    ancestry_path = subprocess.check_output(
+        (
+            "git",
+            "rev-list",
+            f"{commit}..{branch}",
+            "--ancestry-path",
+        ),
+        encoding="utf-8",
+    ).splitlines()
+
+    first_parent = subprocess.check_output(
+        (
+            "git",
+            "rev-list",
+            f"{commit}..{branch}",
+            "--first-parent",
+        ),
+        encoding="utf-8",
+    ).splitlines()
+
+    common_commits = reversed(
+        [commit for commit in ancestry_path if commit in first_parent]
+    )
+    return next(common_commits)
+
+
+def show_commit(commit: str, format: str = "format:%H"):
+    return subprocess.check_output(
+        (
+            "git",
+            "show",
+            "--no-patch",
+            "--no-notes",
+            f"--pretty={format}",
+            commit,
+        ),
+        encoding="utf-8",
+    ).partition("\n")[0]
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", nargs="+", help="Path to news/ directory")
+    parser.add_argument(
+        "-b",
+        "--branch",
+        required=True,
+        help="Branch to check the merge date of",
+    )
+    parser.add_argument(
+        "-n",
+        "--dry-run",
+        action="store_true",
+        help="Do not actually change files",
+    )
+    args = parser.parse_args(argv)
+
+    branch = args.branch
+
+    for path in args.path:
+        with os.scandir(path=path) as it:
+            for entry in it:
+                if not entry.is_file():
+                    continue
+
+                matchobj = re.match(
+                    r"^([0-9X]{4})-XX-XX-(?P<title>.*)$", entry.name
+                )
+                if not matchobj:
+                    continue
+
+                filepath = os.path.join(path, entry.name)
+                print(f"Found file: {filepath}")
+                commit, _, commit_msg = find_commit_that_added_file(
+                    filepath
+                ).partition(" ")
+                print(f"  Added in commit: {commit}")
+                print(f"    {commit_msg}")
+                merge_commit = find_merge_commit_to_branch(commit, branch)
+                print(f"  Merged to {branch} in commit: {merge_commit}")
+                merge_datestr, _, merge_msg = show_commit(
+                    merge_commit, format="%cI %s"
+                ).partition(" ")
+                print(f"    {merge_msg}")
+                merge_datetime = datetime.datetime.fromisoformat(merge_datestr)
+                print(f"  Merge date: {merge_datetime}")
+
+                post_date = merge_datetime.strftime("%Y-%m-%d %H:%M:%S")
+
+                title = matchobj.group("title")
+                date = merge_datetime.strftime("%Y-%m-%d")
+                new_filepath = os.path.join(path, f"{date}-{title}")
+                print(f"  New filename: {new_filepath}")
+
+                if os.path.exists(new_filepath):
+                    print("  Skipping because new filename already exists!")
+                    print("")
+                    continue
+
+                print("")
+
+                if args.dry_run:
+                    continue
+
+                with open(
+                    filepath, mode="r+", encoding="utf-8", newline="\n"
+                ) as fp:
+                    header, sep, body = fp.read().partition("\n\n")
+                    matchobj = RE_POST_DATE.findall(header)
+                    if matchobj:
+                        header = RE_POST_DATE.sub(f"date: {post_date}", header)
+                    else:
+                        header += f"\ndate: {post_date}"
+
+                    fp.seek(0)
+                    fp.write(header)
+                    fp.write(sep)
+                    fp.write(body)
+                    fp.truncate()
+
+                os.rename(filepath, new_filepath)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
After merging a new blog post into the `website` branch, this automatically updates the blog post date to the commit date of the merge commit if the filename starts with `XXXX-XX-XX-` or `2020-XX-XX`. It renames the file and updates the `date:` entry, then commits and pushes the changes automatically. 

Afterwards, it automatically triggers a redeploy on Netlify if the `NETLIFY_BUILD_HOOK` secret is defined: https://docs.netlify.com/configure-builds/build-hooks/
(git pushes from GitHub don't trigger web hooks automatically to prevent endless loops)

Therefore, we don't have to keep up with bumping the dates manually all the time.