### PR TITLE
Netlify: Fix discourse comments blocked by CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -45,4 +45,4 @@
   for = "/news/*"
   [headers.values]
     # Additionally allow YouTube/Discourse frames and scripts
-    Content-Security-Policy = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'sha256-UPkidoMErzWw1gW/eY4LhAi9ZkPch3PP31d6KQoJ6Yc=' 'sha256-XCSOkdT9euLHstE3pfzL3lwXCbpDeHaVjoQtlRgny60=' https://ssl.google-analytics.com/ga.js https://mixxx.discourse.group/javascripts/embed.js 'sha256-6q+coHkwpyuBHHI7+nDAZewGV9mVIuZU5UJyx19Gdrs='; frame-src 'self' https://www.youtube-nocookie.com https://mixxx.discourse.group ; img-src 'self' https://i.ytimg.com ; connect-src 'self' https://mixxx.discourse.group https://*.discourse-cdn.com"
+    Content-Security-Policy = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://ssl.google-analytics.com/ga.js https://mixxx.discourse.group/javascripts/embed.js; frame-src 'self' https://www.youtube-nocookie.com https://mixxx.discourse.group ; img-src 'self' https://i.ytimg.com ; connect-src 'self' https://mixxx.discourse.group https://*.discourse-cdn.com"


### PR DESCRIPTION
Without this, discourse comments are blocked by our CSP.