### PR TITLE
pages/download: Expand section if URL contains an anchor

### DIFF
--- a/theme/static/js/download.js
+++ b/theme/static/js/download.js
@@ -38,12 +38,21 @@
         return null;
     }
 
-    let os = detectOS();
-    if (os === null) {
-        return;
-    }
-
     document.addEventListener("DOMContentLoaded", function() {
+        // Expand section that has been navigated to with an anchor
+        if (document.location.hash) {
+            let anchorButton = document.querySelector(".accordion " + location.hash + " > input.expander");
+            if (anchorButton) {
+                anchorButton.checked = true;
+            }
+        }
+
+        let os = detectOS();
+        if (os === null) {
+            return;
+        }
+
+        // Update the "Download" button at the top of the page
         let button = document.querySelector("#download .download-button")
         if (!button) {
             return;

--- a/theme/static/js/download.js
+++ b/theme/static/js/download.js
@@ -38,15 +38,23 @@
         return null;
     }
 
-    document.addEventListener("DOMContentLoaded", function() {
-        // Expand section that has been navigated to with an anchor
+    let expandAccordionByHash = function() {
         if (document.location.hash) {
             let anchorButton = document.querySelector(".accordion " + location.hash + " > input.expander");
             if (anchorButton) {
                 anchorButton.checked = true;
+
+                // Re-scoll to anchor (works around wrong scroll position
+                // caused by the accordion changes *after* we already scrolled).
+                let section = document.querySelector(".accordion " + location.hash)
+                if (section) {
+                    section.scrollIntoView();
+                }
             }
         }
+    }
 
+    let updateDownloadButton = function() {
         let os = detectOS();
         if (os === null) {
             return;
@@ -107,7 +115,10 @@
             button.href = "#" + section.id;
             button.innerHTML = button.dataset.osdetectText.replace("%s", section.dataset.os);
             description.innerHTML = description.dataset.osdetectText;
-            input.checked = true;
         }
-    });
+    }
+
+    window.addEventListener('hashchange', expandAccordionByHash);
+    document.addEventListener("DOMContentLoaded", expandAccordionByHash);
+    document.addEventListener("DOMContentLoaded", updateDownloadButton);
 }());


### PR DESCRIPTION
This expands the appropriate section automatically when using a link like: https://mixxx.org/download/#stable-macos