### PR TITLE
Remove download links to Deb files.

### DIFF
--- a/content/pages/download.md
+++ b/content/pages/download.md
@@ -32,13 +32,6 @@ versions:
           Using the PPA ensures that new package versions will be installed automatically with `apt`. Otherwise, you can download individual packages and install them manually.
         note: |
           **Note:** Ubuntu also provides a version of Mixxx which can be installed directly from the Ubuntu Software Centre. This version is usually woefully out of date; therefore using the PPA is advised.
-        packages:
-        - slug: ubuntu32
-          name: 32-Bit
-          url: https://downloads.mixxx.org/builds/2.3/release/mixxx-2.3.0-beta-2.3-release-bionic-i386-latest.deb
-        - ubuntu64:
-          name: 64-Bit
-          url: https://downloads.mixxx.org/builds/2.3/release/mixxx-2.3.0-beta-2.3-release-bionic-amd64-latest.deb
       - slug: fedora
         os: Fedora
         text: |
@@ -109,13 +102,6 @@ versions:
           Using the PPA ensures that new package versions will be installed automatically with `apt`. Otherwise, you can download individual packages and install them manually.
         note: |
           **Note:** Ubuntu also provides a version of Mixxx which can be installed directly from the Ubuntu Software Centre. This version is usually woefully out of date; therefore using the PPA is advised.
-        packages:
-          - slug: ubuntu32
-            name: 32-Bit
-            url: https://downloads.mixxx.org/mixxx-2.2.4/mixxx-2.2.4-bionic-i386.deb
-          - slug: ubuntu64
-            name: 64-Bit
-            url: https://downloads.mixxx.org/mixxx-2.2.4/mixxx-2.2.4-bionic-amd64.deb
       - slug: fedora
         os: Fedora
         text: |

--- a/content/pages/download.md
+++ b/content/pages/download.md
@@ -29,7 +29,7 @@ versions:
               $ sudo apt update
               $ sudo apt install mixxx
 
-          Using the PPA ensures that new package versions will be installed automatically with `apt`. Otherwise, you can download individual packages and install them manually.
+          Using the PPA ensures that new package versions will be installed automatically with `apt`. Otherwise, you can [download individual packages](https://launchpad.net/~mixxx/+archive/ubuntu/mixxxbetas/+packages) and install them manually.
         note: |
           **Note:** Ubuntu also provides a version of Mixxx which can be installed directly from the Ubuntu Software Centre. This version is usually woefully out of date; therefore using the PPA is advised.
       - slug: fedora
@@ -99,7 +99,7 @@ versions:
               $ sudo apt update
               $ sudo apt install mixxx
 
-          Using the PPA ensures that new package versions will be installed automatically with `apt`. Otherwise, you can download individual packages and install them manually.
+          Using the PPA ensures that new package versions will be installed automatically with `apt`. Otherwise, you can [download individual packages](https://launchpad.net/~mixxx/+archive/ubuntu/mixxx/+packages) and install them manually.
         note: |
           **Note:** Ubuntu also provides a version of Mixxx which can be installed directly from the Ubuntu Software Centre. This version is usually woefully out of date; therefore using the PPA is advised.
       - slug: fedora


### PR DESCRIPTION
These are only useful in rare cases, and not recommended because bypassing the security a PPA build provides.

In addition the 2.3 beta is still at the August version. 