### PR TITLE
tools/update_news_date: Fix script for squash-and-merge strategy

### DIFF
--- a/tools/update_news_date.py
+++ b/tools/update_news_date.py
@@ -110,13 +110,15 @@ def main(argv=None):
                 try:
                     merge_commit = find_merge_commit_to_branch(commit, branch)
                 except StopIteration:
-                    print("  Skipping because the merge commit was not found!")
-                    continue
-                print(f"  Merged to {branch} in commit: {merge_commit}")
-                merge_datestr, _, merge_msg = show_commit(
-                    merge_commit, format="%cI %s"
-                ).partition(" ")
-                print(f"    {merge_msg}")
+                    print("Merge commit not found, assuming squash-and-merge!")
+                    merge_datestr = show_commit(commit, format="%cI")
+                else:
+                    print(f"  Merged to {branch} in commit: {merge_commit}")
+                    merge_datestr, _, merge_msg = show_commit(
+                        merge_commit, format="%cI %s"
+                    ).partition(" ")
+                    print(f"    {merge_msg}")
+
                 merge_datetime = datetime.datetime.fromisoformat(merge_datestr)
                 print(f"  Merge date: {merge_datetime}")
 


### PR DESCRIPTION
When merging a blog post using squash-and-merge, no merge commit is created. This makes the `update_news_date.py` script fail because it can't find the corresponding merge commit. This was the case for #217. It only worked when #240 was merged, because now the blog post was part of a merge commit (see https://github.com/mixxxdj/website/runs/2536666268?check_suite_focus=true)

This fixes the issue by supporting squash-and-merge, too.