### PR TITLE
add launchpad linkt to Support menu

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -148,6 +148,11 @@ NAV_MENU = (
                 "Navigation bar link to Mixxx Forums.",
             ),
             MenuItem(
+                "https://bugs.launchpad.net/mixxx/",
+                "Bug Tracker",
+                "Navigation bar link to Mixxx Bug Tracker.",
+            ),
+            MenuItem(
                 "https://github.com/mixxxdj/mixxx/wiki",
                 "Wiki",
                 "Navigation bar link to Mixxx Wiki.",


### PR DESCRIPTION
briefly discussed in https://mixxx.zulipchat.com/#narrow/stream/248802-website/topic/add.20launchpad.20link.20to.20Support.20menu.3F

![image](https://user-images.githubusercontent.com/5934199/135282725-b755f10c-5800-45eb-ad3d-8696a310136d.png)
