### PR TITLE
supported controllers: link to manual instead of wiki page

### DIFF
--- a/theme/templates/pages/features.html
+++ b/theme/templates/pages/features.html
@@ -81,7 +81,7 @@
         <p>
           {% trans %}for controllers such as the Pioneer DDJ-SB2, Numark Mixtrack Pro 3, Allen &amp; Heath Xone K2, Hercules DJ Console Series, and many more.{% endtrans %}
         </p>
-        <a class="button button-secondary" href="https://github.com/mixxxdj/mixxx/wiki/Hardware-Compatibility">{% trans %}Supported Devices{% endtrans %}</a>
+        <a class="button button-secondary" href="https://manual.mixxx.org/latest/hardware/manuals.html#hardware-manuals">{% trans %}Supported Devices{% endtrans %}</a>
 
         <h6 class="docs-header">{% trans %}Programmable Mapping Engine{% endtrans %}</h6>
         <p>


### PR DESCRIPTION
Quick fix for https://github.com/mixxxdj/website/issues/254