### PR TITLE
POC for a Controller Hotlist page

### DIFF
--- a/content/pages/controller-hotlist.md
+++ b/content/pages/controller-hotlist.md
@@ -1,0 +1,9 @@
+---
+title: Controller Hotlist
+template: pages/controller-hotlist
+controllers:
+  replaced_by_discourse_hotlist_py:
+    name: Hercules RMX 2
+    forum_link: https://mixxx.discourse.group/t/custom-midi-mapping-hercules-rmx-2-0-1-3
+    heat: 78
+...

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -127,11 +127,6 @@ NAV_MENU = (
                 "Navigation bar link to Mixxx Press page",
             ),
             MenuItem(
-                "/controller-hotlist",
-                "Hot-List",
-                "Navigation bar link to Mixxx Controller Hotlist",
-            ),
-            MenuItem(
                 "/contact",
                 "Contact & Team",
                 "Navigation bar link to Mixxx contact page.",

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -89,6 +89,7 @@ PLUGIN_PATHS = [
 PLUGINS = [
     "author_metadata",
     "download_metadata",
+    "discourse_hotlist",
     "draft_override",
     "md_yaml",
 ]
@@ -124,6 +125,11 @@ NAV_MENU = (
                 "/press",
                 "Press",
                 "Navigation bar link to Mixxx Press page",
+            ),
+            MenuItem(
+                "/controller-hotlist",
+                "Hot-List",
+                "Navigation bar link to Mixxx Controller Hotlist",
             ),
             MenuItem(
                 "/contact",

--- a/plugins/discourse_hotlist/__init__.py
+++ b/plugins/discourse_hotlist/__init__.py
@@ -1,0 +1,3 @@
+from .discourse_hotlist import register
+
+__all__ = ["register"]

--- a/plugins/discourse_hotlist/discourse_hotlist.py
+++ b/plugins/discourse_hotlist/discourse_hotlist.py
@@ -1,0 +1,61 @@
+import json
+import logging
+import datetime
+import urllib.request
+from pelican import signals
+
+# from pydiscourse import DiscourseClient
+
+
+def format_size(num, suffix="B"):
+    """Convert a file size in bytes into a human-readable format."""
+    for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
+        if abs(num) < 1024.0:
+            return "%3.1f%s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f%s%s" % (num, "Yi", suffix)
+
+
+def url_add_query_params(original_url, query_params):
+    """Returns the URL with the given query parameters added."""
+    url = urllib.parse.urlparse(original_url)
+    query = urllib.parse.parse_qs(url.query)
+    query.update(query_params)
+    query = urllib.parse.urlencode(query)
+    return urllib.parse.urlunparse(
+        (url.scheme, url.netloc, url.path, url.params, query, url.fragment)
+    )
+
+
+def page_generator_context(page_generator, metadata):
+    """
+    Iterate through page objects and augment the download page's package data
+    with information from the download manifest file (if specified).
+    """
+    logger = logging.getLogger(__name__)
+
+    controllers = metadata.get("controllers", {})
+
+    # check if the page has controllers in the metadata
+    if controllers:
+        # remove dummy entry
+        controllers.clear()
+
+        for x in range(10):
+            streetno = {}
+            streetno["name"] = "Fancy Controller"
+            streetno["heat"] = x
+            streetno[
+                "forum_link"
+            ] = "https://mixxx.discourse.group/t/denon-sc2000/11122"
+            controllers[str(x)] = streetno
+
+        # client = DiscourseClient(
+        #    'https://mixxx.discourse.group/',
+        #    api_username='username',
+        #    api_key='areallylongstringfromdiscourse')
+
+
+def register():
+    """ Subscribe to Pelican's signals. """
+    signals.page_generator_context.connect(page_generator_context)

--- a/theme/templates/pages/controller-hotlist.html
+++ b/theme/templates/pages/controller-hotlist.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block title %}{% trans %}List the hottest controllers based on forums activity{% endtrans %}{% endblock %}
+
+{% block body %}
+
+<div id="controller-hotlist" class="docs-section container">
+  <h1><a class="headline-link" href="#controller-hotlist">Controller Hotlist</a></h1>
+  <p>{% trans %}This is the list of hottest controllers based on forums activity.{% endtrans %}</p>
+  <p>
+    <ul>
+      {% for controller, controller_data in page.controllers.items() %}
+        <li>
+        {{ controller_data.name }} &nbsp;&nbsp;&nbsp; &#x1F525; {{ controller_data.heat }} &nbsp;&nbsp;&nbsp; <a href="{{ controller_data.forum_link }}">&#x2197;</a>
+        </li>
+      {% endfor %}
+    </ul>
+  </p>
+</div>
+
+<div id="donate" class="docs-section container">
+  <p>
+    {% with controller_mappings_forums_link="https://mixxx.discourse.group/c/controller-mappings" %}
+    {% trans %}
+    This list is created based on recent forums aktivity in the
+    <a href="{{ controller_mappings_forums_link }}">Controller Mapping</a> category.
+    To keep this list updated you are encouraged to created topics in the forums named
+    like an not yet supported controller. Even if you are not able to take the technical
+    challenge and create a mapping on your own, it helps us to keep this list updated.
+    If your controller is already on the list, you can leave a &#9829; (a like).
+    This is taken into account when generating this list and will help to give us a good
+    overview of the controller market in relation to Mixxx. However, a high number of likes
+    alone does not mean that Mixxx will support that controller soon. To create an official
+    controller we need the controller itself a contributor who has interest to create the
+    controller mapping along with documentation and a tester/reviewer who verifies the quality of the
+    mapping.
+    {% endtrans %}
+    {% endwith %}
+  </p>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
This is a prove of concept of a Controller Hotlist generated from user interactions on Discourse. 

What do you think about it. The magic formula to create the heat value for a controller is missing. I need a read only API key to continue here. 

In addition we need an ignore list to ignore topics not specific for a certain model and a filter that can mark controllers already supported. 

My idea is this magic formula:
Consider all data younger than three years. 
heat = ("number actions by user per controller" camped to 0 .. 2) * 3 - last action age form user in years. 

What do you think?   


 