### PR TITLE
Remove extra spaces in docstrings

### DIFF
--- a/plugins/download_metadata/download_metadata.py
+++ b/plugins/download_metadata/download_metadata.py
@@ -105,5 +105,5 @@ def page_generator_context(page_generator, metadata):
 
 
 def register():
-    """ Subscribe to Pelican's signals. """
+    """Subscribe to Pelican's signals."""
     signals.page_generator_context.connect(page_generator_context)


### PR DESCRIPTION
This silences a black pre-commit warning. 