### PR TITLE
Reduce mastodon backlink rel=mes to only one

### DIFF
--- a/theme/templates/footer.html
+++ b/theme/templates/footer.html
@@ -15,7 +15,7 @@
         <ul>
           <li><a href="https://mixxx.discourse.group/">Forums</a></li>
           <li>
-            <a rel="me" class="mastodon social_icon" href="https://floss.social/@mixxx" target="_blank">
+            <a class="mastodon social_icon" href="https://floss.social/@mixxx" target="_blank">
               <img src="{{ SITEURL }}/theme/images/social_icons/mastodon.svg" alt="Mastodon">
               <span>Mastodon</span>
             </a>

--- a/theme/templates/social_links.html
+++ b/theme/templates/social_links.html
@@ -1,6 +1,6 @@
 <ul class="social_links">
   <li>
-    <a rel="me" class="mastodon social_icon" href="https://floss.social/@mixxx" target="_blank">
+    <a class="mastodon social_icon" href="https://floss.social/@mixxx" target="_blank">
       <img src="{{ SITEURL }}/theme/images/social_icons/mastodon.svg">
       <span>Mastodon</span>
     </a>


### PR DESCRIPTION
Multiple backlinks can confuse the verifier, and it's not working right now