### PR TITLE
Warn for non XXXX-XX-XX-my-post-title.md news articles

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -47,7 +47,7 @@ PAGINATION_PATTERNS = (
     (1, "{url}", "{save_as}"),
     (2, "{base_name}/page/{number}/", "{base_name}/page/{number}/index.html"),
 )
-FILENAME_METADATA = r"(?P<date>\d{4}-\d{2}-\d{2})-(?P<slug>.*)"
+FILENAME_METADATA = r"^((?P<date>\d{4}-\d{2}-\d{2})|XXXX-XX-XX)-(?P<slug>.+)$"
 DEFAULT_METADATA = {
     "comments": "yes",
 }

--- a/plugins/draft_override/draft_override.py
+++ b/plugins/draft_override/draft_override.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import logging
 
 from pelican import signals
 
@@ -7,6 +8,13 @@ from pelican import signals
 def article_generator_context(article_generator, metadata):
     if metadata.get("status") != "draft":
         return
+
+    if "slug" not in metadata:
+        logger = logging.getLogger(__name__)
+        logger.warning(
+            "Draft article: '%s' is not named according to XXXX-XX-XX-my-post-title.md",
+            metadata["title"],
+        )
 
     # This environment variable is set when building a deploy preview on
     # Netlify. We use it to update the draft status of articles to "published",

--- a/tools/update_news_date.py
+++ b/tools/update_news_date.py
@@ -94,9 +94,7 @@ def main(argv=None):
                 if not entry.is_file():
                     continue
 
-                matchobj = re.match(
-                    r"^([0-9X]{4})-XX-XX-(?P<title>.*)$", entry.name
-                )
+                matchobj = re.match(r"^XXXX-XX-XX-(?P<slug>.+)$", entry.name)
                 if not matchobj:
                     continue
 
@@ -124,9 +122,9 @@ def main(argv=None):
 
                 post_date = merge_datetime.strftime("%Y-%m-%d %H:%M:%S")
 
-                title = matchobj.group("title")
+                slug = matchobj.group("slug")
                 date = merge_datetime.strftime("%Y-%m-%d")
-                new_filepath = os.path.join(path, f"{date}-{title}")
+                new_filepath = os.path.join(path, f"{date}-{slug}")
                 print(f"  New filename: {new_filepath}")
 
                 if os.path.exists(new_filepath):


### PR DESCRIPTION
This adds a warning that is issued  during a PR if the file is not correctly named and the update_news_date.py will fail after merging to the website branch. 

This PR also aligns the used reg-expression, to enure the results are matching. 

I have prepared here a PR with a good and a bad example. 
https://github.com/daschuer/website/actions/runs/4297143440/jobs/7489749558

This should help to avoid noticing a deployment issue early before merge. 
This has happened here: https://github.com/mixxxdj/website/pull/290
