### PR TITLE
Download link for ARM macOS 

### DIFF
--- a/content/pages/download.md
+++ b/content/pages/download.md
@@ -14,6 +14,8 @@ versions:
             name: 64-Bit
       - slug: macos
         os: macOS 10.12 or later
+        text: |
+          Download Mixxx 2.3.5 for Intel macOS 10.12 or later. This also runs with Rosetta 2 on ARM macOS (Apple silicon). Alternatively use the the native ARM build development snapshot from below.  
         packages:
         - slug: macosintel
           name: Intel
@@ -85,6 +87,8 @@ versions:
             name: 64-Bit
       - slug: macos
         os: macOS 10.12 or later
+        text: |
+          Download Mixxx 2.5-alpha for Intel macOS 10.12 or later or for ARM macOS 11.0 or later (Apple silicon M1/M2). Check your OS by clicking the Apple Logo in the menu bar, then About this Mac -> If chip contains Apple M..., then download the ARM build.
         packages:
         - slug: macosintel
           name: Intel

--- a/content/pages/download.md
+++ b/content/pages/download.md
@@ -88,7 +88,7 @@ versions:
       - slug: macos
         os: macOS 10.12 or later
         text: |
-          Download Mixxx 2.5-alpha for Intel macOS 10.12 or later or for ARM macOS 11.0 or later (Apple silicon M1/M2). Check your OS by clicking the Apple Logo in the menu bar, then About this Mac -> If chip contains Apple M..., then download the ARM build.
+          Download Mixxx 2.5-alpha for Intel macOS 10.12 or later or for ARM macOS 11.0 or later (Apple silicon M1/M2). You can check which version you need by clicking the Apple logo in the menu bar, then "About this Mac". If the window displays an "Apple M..." chip, download the ARM build, otherwise you need the Intel build.
         packages:
         - slug: macosintel
           name: Intel

--- a/content/pages/download.md
+++ b/content/pages/download.md
@@ -87,6 +87,8 @@ versions:
         packages:
         - slug: macosintel
           name: Intel
+        - slug: macosarm
+          name: ARM
       - slug: ubuntu
         os: Ubuntu 20.04 "Focal Fossa" or later
         text: |

--- a/content/pages/download.md
+++ b/content/pages/download.md
@@ -70,6 +70,7 @@ versions:
           name: 2.3.5 release
           file_url: https://github.com/mixxxdj/mixxx/archive/2.3.5.tar.gz
   testing:
+    name: 2.5-alpha
     title: Development Snapshots
     text: |
       A great way to contribute to Mixxx is testing the latest code we're working on and giving early feedback. Refer to the [Testing wiki page](https://github.com/mixxxdj/mixxx/wiki/Testing) for where to find the latest builds and instructions how to test pull requests before they are merged.

--- a/theme/static/js/download.js
+++ b/theme/static/js/download.js
@@ -23,11 +23,11 @@
         if (window.navigator.userAgent.indexOf("Windows") !== -1) {
             return ["windows", "win" + detectBitness()];
         }
-        if (window.navigator.userAgent.indexOf("Intel Mac") !== -1) {
-            return ["macos", ["macosintel"]];
-        }
-        if (window.navigator.userAgent.indexOf("ARM Mac") !== -1) {
-            return ["macos", ["macosarm"]];
+        // The user agent of ARM Mac can be "Intel Mac" as well,
+        // so we cannot directly download "macosintel" here.
+        // [] scrolls to the two buttons for manual selection.
+        if (window.navigator.userAgent.indexOf("Mac") !== -1) {
+            return ["macos", []];
         }
         if (window.navigator.userAgent.indexOf("Ubuntu") !== -1) {
             return ["ubuntu", []];

--- a/theme/static/js/download.js
+++ b/theme/static/js/download.js
@@ -23,8 +23,11 @@
         if (window.navigator.userAgent.indexOf("Windows") !== -1) {
             return ["windows", "win" + detectBitness()];
         }
-        if (window.navigator.userAgent.indexOf("Mac") !== -1) {
+        if (window.navigator.userAgent.indexOf("Intel Mac") !== -1) {
             return ["macos", ["macosintel"]];
+        }
+        if (window.navigator.userAgent.indexOf("ARM Mac") !== -1) {
+            return ["macos", ["macosarm"]];
         }
         if (window.navigator.userAgent.indexOf("Ubuntu") !== -1) {
             return ["ubuntu", []];

--- a/theme/templates/pages/download.html
+++ b/theme/templates/pages/download.html
@@ -121,9 +121,9 @@
         {% if download.text %}
         {{ download.text|markdown }}
         {% elif download.os %}
-        <p>Download Mixxx {{ version_name }} for {{ download.os }}.</p>
+        <p>Download Mixxx {{ version.name }} for {{ download.os }}.</p>
         {% else %}
-        <p>Download Mixxx {{ version_name }}.</p>
+        <p>Download Mixxx {{ version.name }}.</p>
         {% endif %}
 
         {% if download.packages %}


### PR DESCRIPTION
This should add the link to download ARM macOS. 
It also tries to detect the user agent architecture to download the right binary when pressing the download button. 