### PR TITLE
Darken splash and cover backgrounds to lower contrast and improve readability

### DIFF
--- a/theme/static/css/pages/features.css
+++ b/theme/static/css/pages/features.css
@@ -1,9 +1,9 @@
 #hardware.cover-bg {
-    background-image: url('/theme/images/cover/hardware-bg.jpg');
+    background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('/theme/images/cover/hardware-bg.jpg');
 }
 
 #library.cover-bg {
-    background-image: url('/theme/images/cover/library-bg.jpg');
+    background-image: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url('/theme/images/cover/library-bg.jpg');
 }
 
 #broadcast.cover-bg {

--- a/theme/static/css/pages/index.css
+++ b/theme/static/css/pages/index.css
@@ -1,5 +1,5 @@
 .splash.cover-bg {
-    background-image: url('/theme/images/cover/splash-bg.jpg');
+    background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.9)), url('/theme/images/cover/splash-bg.jpg');
 }
 
 .splash .splash-logo {


### PR DESCRIPTION
I have noticed that the current splash background is a bit high in contrast, making the headline hard to read. Also, the logo and the social media icons just blend in too much with the background:

<img width="1429" alt="Screenshot 2024-01-16 at 14 43 01" src="https://github.com/mixxxdj/website/assets/30873659/b73bb78f-b7ff-4a70-b990-e00dea5378c8">

Adding a small gradient alleviates this issue and makes the website simultaneously appear a bit more polished:

<img width="1429" alt="Screenshot 2024-01-16 at 14 43 15" src="https://github.com/mixxxdj/website/assets/30873659/577e668c-3cd0-44a2-952c-8c534c7263ac">

The nice thing about modeling this in CSS is that we can freely swap the image without changing the gradient.

In addition to the banner, I've also added some, slightly lower, gradients to backgrounds on the feature page, where the contrast is IMO a bit high too, though the specific opacities are of course up for debate:

| Before | After |
| - | - |
| ![Screenshot](https://github.com/mixxxdj/website/assets/30873659/492641c2-4fe4-4fe8-925c-8c2ae4ea287d) | ![Screenshot](https://github.com/mixxxdj/website/assets/30873659/0a96726b-363d-4b20-bc77-a6af6946f0a2) |
![Screenshot](https://github.com/mixxxdj/website/assets/30873659/c5cfc276-13f7-442b-8873-0b07b6b2d0c4) |  ![Screenshot](https://github.com/mixxxdj/website/assets/30873659/9195e54f-1b54-4ec0-b0b2-89582fe97570) |

Thoughts?