### PR TITLE
fix(theme): Fix video plugin always using video ID from first video

### DIFF
--- a/theme/static/js/video.js
+++ b/theme/static/js/video.js
@@ -2,7 +2,7 @@
     document.addEventListener("DOMContentLoaded", function() {
         // Your code to run since DOM is loaded and ready
         for (let element of document.querySelectorAll(".video-container")) {
-            let dialog = document.querySelector(".video-dialog");
+            let dialog = element.querySelector(".video-dialog");
             let videoId = dialog.dataset.source;
             let button = element.querySelector(".video-button");
             button.addEventListener("click", function() {


### PR DESCRIPTION
See: https://mixxx.zulipchat.com/#narrow/stream/248802-website/topic/2.2E4.20Release.20blogpost.20-.20Pelican.3A.20Multiple.20videos.20do.20not.20work/near/418451245

Note that you might need to clear your browser cache.