### PR TITLE
chore(news): Add some fixes for improved waveforms blogpost

### DIFF
--- a/content/news/2024-02-23-improved-waveforms.md
+++ b/content/news/2024-02-23-improved-waveforms.md
@@ -26,12 +26,19 @@ Additionally, the markers layer has been improved: Multiple markers at the same 
 
 ## Some technical insights
 
-Mixxx uses the Qt software framework for its user interface. Originally the layers that form the scrolling waveform display were rendered on the now deprecated QGLWidget through a combination of 'QPainter' and Legacy OpenGL function calls. Profiling showed that this combination was a performance bottleneck, particularly on macOS.
+Mixxx uses the Qt software framework for its user interface. Originally the layers that form the scrolling waveform display were rendered on the now deprecated [`QGLWidget`][qglwidget] through a combination of [`QPainter`][qpainter] and legacy OpenGL function calls. Profiling showed that this combination was a performance bottleneck, particularly on macOS.
 
-With the rewrite, all the layers mentioned above are now implemented using Modern OpenGL code: All different waveform types, i.e, Simple, Filtered, HSV, RGB and RGB L/R, are now hardware accelarated using GLSL shaders. In addition to the waveforms, the spinny widgets and VU-meters code has been revised with the same approach.
+With the rewrite, all the layers mentioned above are now implemented using modern OpenGL code: All different waveform types, i.e, Simple, Filtered, HSV, RGB and RGB L/R, are now hardware accelerated using GLSL shaders. In addition to the waveforms, the Spinny widgets and VU-meters code has been revised with the same approach.
 
-The deprecated QGLWidget has been replaced by a custom solution using a QOpenGLWindow inside a QWidget using the createWindowContainer() call. Qt also offers QOpenGLWidget to replace QGLWidget, but the QOpenGLWindow solution resulted in better performance and integrated better with the existing source code. This change will also facilitate the migration to Qt 6, planned for Mixxx 2.5.
+The deprecated `QGLWidget` has been replaced by a custom solution using a [`QOpenGLWindow`][qopenglwindow] inside a [`QWidget`][qwidget] using the [`createWindowContainer()`][qwidget-createwindowcontainer] call. Qt also offers `QOpenGLWidget` to replace `QGLWidget`, but the `QOpenGLWindow` solution resulted in better performance and integrated better with the existing source code. This change will also facilitate the migration to Qt 6, planned for Mixxx 2.5.
 
 ## New display synchronization mode
 
-To avoid visual jitter, the rendered waveform has to be displayed at the right moment. This is achieved by synchronising the scrolling waveform animation with the display refresh rate. As a last minute addition, an alternative mode to do so has been introduced, using a so-called phase-locked-loop (PLL). This mechanism attempts to track the actual refresh rate and timing of the display automatically. On particular hardware, the default periodic timer-based approach can result in jitter and frame drops, and the PLL may give better results. The PLL has been made the default on macOS, where the improvement was most noticeable; on other platforms your mileage may vary. See [instructions to change the V-Sync mode](https://github.com/mixxxdj/mixxx/wiki/Changing-the-VSync-Mode-for-Scrolling-Waveforms) if you want to try which mode works best for you. Note that this setting does not effect the audio control performance.
+To avoid visual jitter, the rendered waveform has to be displayed at the right moment. This is achieved by synchronising the scrolling waveform animation with the display refresh rate. As a last minute addition, an alternative mode to do so has been introduced, using a so-called phase-locked-loop (PLL). This mechanism attempts to track the actual refresh rate and timing of the display automatically. On particular hardware, the default periodic timer-based approach can result in jitter and frame drops, and the PLL may give better results. The PLL has been made the default on macOS, where the improvement was most noticeable; on other platforms your mileage may vary. See [instructions to change the V-Sync mode][change-vsync-mode] if you want to try which mode works best for you. Note that this setting does not effect the audio control performance.
+
+[qglwidget]: https://doc.qt.io/qt-5/qglwidget.html
+[qpainter]: https://doc.qt.io/qt-5/qpainter.html
+[qopenglwindow]: https://doc.qt.io/qt-5/qopenglwindow.html
+[qwidget]: https://doc.qt.io/qt-5/qwidget.html
+[qwidget-createwindowcontainer]: https://doc.qt.io/qt-5/qwidget.html#createWindowContainer
+[change-vsync-mode]: https://github.com/mixxxdj/mixxx/wiki/Changing-the-VSync-Mode-for-Scrolling-Waveforms


### PR DESCRIPTION
This fixes a few typos, adds proper monospace formatting for C++ classes/methods using backticks and adds a few links.