### PR TITLE
Add release roadmap and news to introduce the page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /output
 # python bytecode cache
 __pycache__
+.venv/

--- a/content/news/2024-09-22-previsional-release-roadmap.md
+++ b/content/news/2024-09-22-previsional-release-roadmap.md
@@ -1,0 +1,9 @@
+title: "Introducing the previsional Release Roadmap"
+authors: Antoine Colombier
+tags: development, improvements
+slug: Previsional-Release-Roadmap
+date: 2024-09-22 12:00:00
+
+As of today, we have just introduced a [Previsional Release Roadmap](/release_roadmap) page on the website which will help you keeping track on when to expect new Mixxx releases, with a focus on new minor releases, which are the release containing all the new shiny features that the community is working hard to deliver.
+
+Mixxx is adopting a 6-month development cycle, starting from the soon to come 2.5.0. Going forward, you should expect new release every October and April of each years, similarly to the Ubuntu release cycle. Note that this is only a guideline for the team to know on when to focusing on making a release, but quality will remain the main driver as well as depending on available of the team to complete the release process.

--- a/content/pages/release_roadmap.md
+++ b/content/pages/release_roadmap.md
@@ -1,0 +1,3 @@
+title: Release Roadmap
+slug: release_roadmap
+template: pages/release_roadmap

--- a/netlify.toml
+++ b/netlify.toml
@@ -49,4 +49,11 @@
   for = "/news/*"
   [headers.values]
     # Additionally allow YouTube/Discourse frames and scripts
-    Content-Security-Policy = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'sha256-UPkidoMErzWw1gW/eY4LhAi9ZkPch3PP31d6KQoJ6Yc=' https://mixxx.discourse.group/javascripts/embed.js *.discourse-cdn.com; frame-src 'self' https://www.youtube-nocookie.com https://mixxx.discourse.group ; img-src 'self' https://i.ytimg.com ; connect-src 'self' https://mixxx.discourse.group https://*.discourse-cdn.com"
+    Content-Security-Policy = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'sha256-UPkidoMErzWw1gW/eY4LhAi9ZkPch3PP31d6KQoJ6Yc=' https://mixxx.discourse.group/javascripts/embed.js *.discourse-cdn.com 'sha384-7J/UM6Vde6cXqst3EI86P36213Jz5rooW1EEUvweQ3F3gQOHkTuSKAX67ANmYljn' 'https://cdn.jsdelivr.net/npm/mermaid@11.2.1/dist/mermaid.min.js'; frame-src 'self' https://www.youtube-nocookie.com https://mixxx.discourse.group ; img-src 'self' https://i.ytimg.com ; connect-src 'self' https://mixxx.discourse.group https://*.discourse-cdn.com"
+
+
+[[headers]]
+  for = "/release_roadmap/"
+  [headers.values]
+    # Additionally allow Mermaid script
+    Content-Security-Policy = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'sha384-7J/UM6Vde6cXqst3EI86P36213Jz5rooW1EEUvweQ3F3gQOHkTuSKAX67ANmYljn' 'nonce-VoYlObL+iS4p0ATVpB4f495PwA9FE4obmpj2VWc961Q='"

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -124,6 +124,11 @@ NAV_MENU = (
                 "Navigation bar link to Mixxx Press page",
             ),
             MenuItem(
+                "/release_roadmap",
+                "Release Roadmap",
+                "Navigation bar link to Mixxx Previsional Release Roadmap",
+            ),
+            MenuItem(
                 "/contact",
                 "Contact & Team",
                 "Navigation bar link to Mixxx contact page.",

--- a/theme/static/css/pages/release_roadmap.css
+++ b/theme/static/css/pages/release_roadmap.css
@@ -1,0 +1,38 @@
+.markdown-alert {
+    padding: 0.5rem 1rem;
+    margin-bottom: 1rem;
+    color: inherit;
+    border-left: .25em solid #3d444d;
+}
+.markdown-alert.markdown-alert-important {
+    border-left-color: #8957e5;
+}
+.markdown-alert.markdown-alert-important .markdown-alert-title {
+    color: #8957e5;
+}
+.markdown-alert.markdown-alert-tip {
+    border-left-color: #3fb950;
+}
+.markdown-alert.markdown-alert-tip .markdown-alert-title {
+    color: #3fb950;
+}
+.octicon {
+    margin-right: 8px !important;
+    display: inline-block;
+    overflow: visible !important;
+    vertical-align: text-bottom;
+    fill: currentColor;
+}
+.markdown-alert .markdown-alert-title {
+    display: flex;
+    font-weight: 500;
+    align-items: center;
+    line-height: 1;
+}
+.markdown-body p, .markdown-body blockquote, .markdown-body ul, .markdown-body ol, .markdown-body dl, .markdown-body table, .markdown-body pre, .markdown-body details {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+pre.mermaid:not([data-processed="true"]) {
+    display: none;
+}

--- a/theme/templates/pages/release_roadmap.html
+++ b/theme/templates/pages/release_roadmap.html
@@ -1,0 +1,149 @@
+{% extends "base.html" %}
+
+{% block title %}{% trans %}Previsional Release Roadmap{% endtrans %}{% endblock %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="{{ SITEURL }}/theme/css/pages/release_roadmap.css">
+
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11.2.1/dist/mermaid.min.js" integrity="sha384-7J/UM6Vde6cXqst3EI86P36213Jz5rooW1EEUvweQ3F3gQOHkTuSKAX67ANmYljn" crossorigin="anonymous"></script>
+
+<script type="text/javascript" nonce="VoYlObL+iS4p0ATVpB4f495PwA9FE4obmpj2VWc961Q=">
+  mermaid.initialize({ startOnLoad: true });
+</script>
+
+{% endblock %}
+
+
+{% block body %}
+<div class="docs-section container">
+  <h1>Previsional Release Roadmap</h1>
+
+  <p>
+    This document helps providing visibility. Starting from release 2.5, Mixxx is following <a href="https://github.com/mixxxdj/mixxx/wiki/250_release_proposal#proposal-1-phase-model" target="_blank">a 6-month development cycle</a>. This means that every 6 month, a new minor version is released, with the latest 6-month worth of feature, which may vary depending of the community involvement.
+  </p>
+  <p>
+    This way of working aim to reduce the time it takes for a contributor to see the feature they've worked on being release, while also allowing the Mixxx Core Team not to spend too much time on new release admin tasks.
+  </p>
+
+  <h2>Timeline</h2>
+
+  <div class="markdown-alert markdown-alert-tip" dir="auto">
+    <p class="markdown-alert-title" dir="auto">
+      <svg class="octicon octicon-light-bulb mr-2" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
+        <path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z"></path>
+      </svg>
+      Tip
+    </p>
+    <p dir="auto">Only up to two previous and next releases are kept in this document to keep it manageable. If you are interested in older releases, you may consult the <a href="https://github.com/mixxxdj/mixxx/blob/main/CHANGELOG.md" target="_blank">changelog</a></p>
+  </div>
+
+  <div class="markdown-alert markdown-alert-important" dir="auto">
+    <p class="markdown-alert-title" dir="auto">
+      <svg class="octicon octicon-report mr-2" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
+        <path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
+      </svg>
+      Important
+    </p>
+    <p dir="auto">The date provided for the future release are purely indicative. The Mixxx Core Team reserves the right to adjust them in order to help with team availability and delays in tasks.</p>
+    <p dir="auto">Note that the version is only an indication, and depending of the impact of the features changes, the team may decide to release a major version (3.0)</p>
+  </div>
+
+  <pre class="mermaid">
+      %%{init: { 'theme': 'default' , 'themeVariables': {
+                'cScale0': '#323632', 'cScaleLabel0': '#ffffff', 'cScaleInv0': '#555555',
+                'cScale1': '#139013', 'cScaleLabel1': '#ffffff', 'cScaleInv1': '#555555',
+                'cScale2': '#13901344', 'cScaleLabel2': '#ffffff44', 'cScaleInv2': '#77ff7744',
+                'cScale3': '#32363244', 'cScaleLabel3': '#ffffff44', 'cScaleInv3': '#55555544'
+        } } }%%
+  timeline
+      section Previous releases
+          2.2.x: 2.2.0 (2018/12/24): 2.2.1 (2019/04/22): 2.2.2 (2019/08/10): 2.2.3 (2019/11/26): 2.2.4 (2020/05/15): 2.2.4.1 (2021/02/17)
+          2.3.x: Beta (2020/05/12): 2.3.0 (2021/06/28): 2.3.1 (2021/09/29): 2.3.2 (2022/01/30): 2.3.3 (2022/06/21): 2.3.4 (2023/03/03): 2.3.5 (2023/05/10): 2.3.6 (2023/08/15)
+      section Current release
+          2.4.x: Alpha (2020/05/12): Beta (2023/05/29): 2.4.0 (2024/02/16): 2.4.1 (2024/05/08)
+      section Next release
+          2.5.x: Alpha (2023/01/11): Beta (2024/06/10): 2.5.0 (2024/10/01)
+      section Future releases
+          2.6.x: Alpha (2024/06/26): Beta (2024/12/01): 2.6.0 (2025/04/01)
+          2.7.x: Alpha (2024/12/01): Beta (2025/05/01): 2.6.0 (2025/10/01)
+
+  </pre>
+
+  <h2>Alternative graph</h2>
+
+  <pre class="mermaid">
+  %%{init: {    'theme': 'neutral', 'themeVariables': {
+                'git0': '#323632', 'gitBranchLabel0': '#ffffff',
+                'git1': '#323632', 'gitBranchLabel1': '#ffffff',
+                'git2': '#139013', 'gitBranchLabel2': '#ffffff',
+                'git3': '#13901344', 'gitBranchLabel3': '#ffffff44',
+                'git4': '#32363244', 'gitBranchLabel4': '#ffffff44',
+                'git5': '#32363244', 'gitBranchLabel5': '#ffffff44',
+                  'commitLabelColor': '#ccc',
+                'commitLabelBackground': '#00000000',
+                'commitLabelFontSize': '8px',
+                'tagLabelFontSize': '10px',
+                'tagLabelBackground': '#323632',
+                'tagLabelBorder': '#555555',
+                'tagLabelColor': '#ccc'
+        },
+      'gitGraph': {
+      'rotateCommitLabel': false,
+      'mainBranchName': '2.2',
+      'mainBranchOrder': false,
+      'showBranches': false
+      } } }%%
+  gitGraph:
+      commit id: " "
+      branch 2.3
+      commit id: " "
+      branch "2.4 (Current release)"
+      commit id: " "
+      branch "2.5 (Next release)"
+      commit id: " "
+      branch 2.6
+      commit id: " "
+      branch 2.7
+      commit id: " "
+      checkout 2.2
+      commit id: "2018-12-24" tag: "2.2.0"
+      commit id: "2019-04-22" tag: "2.2.1"
+      commit id: "2019-08-10" tag: "2.2.2"
+      commit id: "2019-11-26" tag: "2.2.3"
+      checkout 2.3
+      commit id: "2020-05-12" tag: "2.3-beta"
+      checkout "2.4 (Current release)"
+      commit id: "2020-05-12 " tag: "2.4-alpha"
+      checkout 2.2
+      commit id: "2020-05-15" tag: "2.2.4"
+      commit id: "2021-02-17" tag: "2.2.4.1"
+      checkout 2.3
+      commit id: "2021-06-28" tag: "2.3.0"
+      commit id: "2021-09-29" tag: "2.3.1"
+      commit id: "2022-01-30" tag: "2.3.2"
+      commit id: "2022-06-21" tag: "2.3.3"
+      checkout "2.5 (Next release)"
+      commit id: "2023-01-11" tag: "2.5-alpha"
+      checkout 2.3
+      commit id: "2023-03-03" tag: "2.3.4"
+      commit id: "2023-05-10" tag: "2.3.5"
+      checkout "2.4 (Current release)"
+      commit id: "2023-05-29" tag: "2.4-beta"
+      checkout 2.3
+      commit id: "2023-08-15" tag: "2.3.6"
+      checkout "2.4 (Current release)"
+      commit id: "2024-02-16" tag: "2.4.0"
+      commit id: "2024-05-08" tag: "2.4.1"
+      checkout 2.6
+      commit id: "2024-05-26" tag: "2.6-alpha"
+      checkout "2.5 (Next release)"
+      commit id: "2024-06-10" tag: "2.5-beta"
+      checkout 2.7
+      commit id: "2024-12-01 " tag: "2.7-alpha"
+      checkout 2.6
+      commit id: "2024-12-01" tag: "2.6-beta"
+      checkout 2.7
+      commit id: "2025-05-01" tag: "2.7-beta"
+  </pre>
+</div>
+{% endblock %}


### PR DESCRIPTION
Note that the CSS still needs to be cleaned up from some of the weird class name.

- [Page](https://deploy-preview-363--mixxx-website.netlify.app/release_roadmap/)
- [News](https://deploy-preview-363--mixxx-website.netlify.app/news/2024-09-22-previsional-release-roadmap/)