### PR TITLE
Fix 2.4.2 link in download page

### DIFF
--- a/content/pages/download.md
+++ b/content/pages/download.md
@@ -3,8 +3,8 @@ title: Download
 template: pages/download
 versions:
   stable:
-    name: 2.4.1
-    release_announcement: /news/2024-11-23-mixxx-2.4.2-released/
+    name: 2.4.2
+    release_announcement: /news/2024-11-27-mixxx-2-4-2-released/
     download_manifest: https://downloads.mixxx.org/releases/2.4.2/manifest.json
     downloads:
       - slug: windows
@@ -71,7 +71,7 @@ versions:
 
               git clone -b 2.4 https://github.com/mixxxdj/mixxx.git
 
-          The 2.4.2 release has been [tagged](https://github.com/mixxxdj/mixxx/releases/tag/2.4.0) with `2.4.0`.
+          The 2.4.2 release has been [tagged](https://github.com/mixxxdj/mixxx/releases/tag/2.4.2) with `2.4.2`.
 
           Compilation instructions are available for [Windows](https://github.com/mixxxdj/mixxx/wiki/Compiling-On-Windows), [macOS](https://github.com/mixxxdj/mixxx/wiki/Compiling-on-macOS), and [Linux](https://github.com/mixxxdj/mixxx/wiki/Compiling-On-Linux).
         packages:
@@ -80,7 +80,7 @@ versions:
           file_url: https://github.com/mixxxdj/mixxx/archive/2.4.zip
         - slug: source
           name: 2.4.2 release
-          file_url: https://github.com/mixxxdj/mixxx/archive/2.4.1.tar.gz
+          file_url: https://github.com/mixxxdj/mixxx/archive/2.4.2.tar.gz
   beta:
     name: 2.5-beta
     release_announcement: /news/2024-06-11-mixxx-2-5-beta-released


### PR DESCRIPTION
We have an issue that the release blogpost is not deployed for some reason. 

Netlify states: 

> All files already uploaded
> All files already uploaded by a previous deploy with the same commits.

Keep investigating