### PR TITLE
fix: replace `\r\n` in blogposts with `\n` after merge

### DIFF
--- a/tools/update_news_date.py
+++ b/tools/update_news_date.py
@@ -133,7 +133,10 @@ def main(argv=None):
                     continue
 
                 with open(
-                    filepath, mode="r", encoding="utf-8", newline="\n"
+                    filepath,
+                    mode="r",
+                    encoding="utf-8",
+                    newline=None,  # translate any \r\n to \n during read
                 ) as fp:
                     header, sep, body = fp.read().partition("\n\n")
                     if not RE_POST_STATUS.findall(header):


### PR DESCRIPTION
This is done to consistently enforce the Unix `\n` (linefeed) line ending convention in the repo even if blogposts where merged with Windows `\r\n` line endings. It also allows the script to easily appropriately handle such files, as before it was unable to properly parse it because it assumed files always were `\n`.

Fixes #371