### PR TITLE
Download: add more Flatpak info

### DIFF
--- a/content/pages/download.md
+++ b/content/pages/download.md
@@ -61,6 +61,10 @@ versions:
           To run the Flatpak:
 
               flatpak run org.mixxx.Mixxx
+
+          **Note:** When migrating from a distribution package or Mixxx built from source code, Mixxx Flatpak will not automatically recover your previous settings and database. Please refer to the [instructions in the manual](https://manual.mixxx.org/latest/chapters/advanced_topics#migrate-your-mixxx-library-and-settings-to-flatpak).
+
+          If you encounter issues with file or device permissions, please refer to the [Mixxx Flatpak repository](https://github.com/flathub/org.mixxx.Mixxx/issuesffltp) first.
       - slug: source
         name: Source Code
         icon: terminal.svg


### PR DESCRIPTION


This adds links to
* settings migration info
https://manual.mixxx.org/latest/chapters/advanced_topics#migrate-your-mixxx-library-and-settings-to-flatpak now
* Mixxx Flathub repo
https://github.com/flathub/org.mixxx.Mixxx/issuesffltp

Manual PR: https://github.com/mixxxdj/manual/pull/742


[preview](https://deploy-preview-386--mixxx-website.netlify.app/download/#stable-flatpak)