### PR TITLE
Add download link for the Windows ARM build

### DIFF
--- a/content/pages/download.md
+++ b/content/pages/download.md
@@ -99,9 +99,9 @@ versions:
         os: Windows 10 build 1809 or later
         packages:
           - slug: win64
-            name: 64-Bit
+            name: x64
           - slug: winarm
-            name: ARM
+            name: ARM64
       - slug: macos
         os: macOS 11 or later
         packages:

--- a/content/pages/download.md
+++ b/content/pages/download.md
@@ -100,6 +100,8 @@ versions:
         packages:
           - slug: win64
             name: 64-Bit
+          - slug: winarm
+            name: ARM
       - slug: macos
         os: macOS 11 or later
         packages:


### PR DESCRIPTION
I am unsure how this is commonly labeled to be unambiguous. 
I don't mind to have different labels as long Windows users feel at home. 