### PR TITLE
Credits drain fix 

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -46,6 +46,23 @@
     X-XSS-Protection = "1; mode=block"
 
 [[headers]]
+  for = "/theme/fonts/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+    Access-Control-Allow-Origin = "*"
+    Vary = "Origin"
+
+[[headers]]
+  for = "/theme/css/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+for = "/theme/images/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
  for = "/news/*"
  [headers.values]
    # Additionally allow YouTube/Discourse frames and scripts and MathJax

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -13,7 +13,7 @@ TIMEZONE = "Europe/Berlin"
 DEFAULT_LANG = "en"
 
 PATH = "content"
-FEED_ATOM = "feed.xml"
+EED_ATOM = None  # "feed.xml"
 
 ARTICLE_PATHS = [
     "news",

--- a/theme/static/css/pages/index.css
+++ b/theme/static/css/pages/index.css
@@ -1,5 +1,5 @@
 .splash.cover-bg {
-    background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.9)), url('/theme/images/cover/splash-bg.jpg');
+    /* background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.9)), url('/theme/images/cover/splash-bg.jpg'); */
 }
 
 .splash .splash-logo {
@@ -28,5 +28,5 @@
 }
 
 #opensource.cover-bg {
-    background-image: url('/theme/images/cover/code-bg.jpg');
+    /* background-image: url('/theme/images/cover/code-bg.jpg'); */
 }

--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -15,7 +15,7 @@
     <!-- Open Graph Protocol metadata (e.g. for Facebook, https://ogp.me/) -->
     <meta property="og:type" content="website"/>
     <meta property="og:url" content="{{ SITEURL }}/{{ output_file }}"/>
-    <meta property="og:image" content="{{ SITEURL }}/theme/images/splash-1080x717.png"/>
+    <!-- <meta property="og:image" content="{{ SITEURL }}/theme/images/splash-1080x717.png"/> -->>
     <meta property="og:image:width" content="1080"/>
     <meta property="og:image:height" content="717"/>
 


### PR DESCRIPTION
This removes the big background images causing 67 % Bandwidth and enables client side caching. This shall save ~15 € per month. 

This is just a quick fix. On a long run we need a different solution. 